### PR TITLE
Add and test Reducers

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,11 +6,12 @@ import App from './Components/App/App';
 import * as serviceWorker from './serviceWorker';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { createStore } from 'redux';
+import { Store, createStore } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import rootReducer from './redux/reducers';
+import { AppStore } from './interfaces';
 
-const store = createStore(rootReducer, composeWithDevTools());
+const store: Store<AppStore> = createStore(rootReducer, composeWithDevTools());
 
 const app = (
   <Provider store={store}>

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -75,3 +75,120 @@ export interface ActionObject {
   type: string,
   [key: string]: any
 }
+
+export interface IAddUserAction {
+  type: 'ADD_USER',
+  user: UserLoginReceived
+}
+
+export interface ILogoutUserAction {
+  type: 'LOG_OUT_USER'
+}
+
+export interface IAddAllActionsAction {
+  type: 'ADD_ALL_ACTIONS',
+  actions: Action[]
+}
+
+export interface IAddNewActionAction {
+  type: 'ADD_NEW_ACTION',
+  action: Action
+}
+
+export interface IAddAllBrainstormsAction {
+  type: 'ADD_ALL_BRAINSTORMS',
+  brainstorms: Brainstorm[]
+}
+
+export interface IAddNewBrainstormAction {
+  type: 'ADD_BRAINSTORM',
+  brainstorm: Brainstorm
+}
+
+export interface IDeleteBrainstormAction {
+  type: 'DELETE_BRAINSTORM',
+  id: number
+}
+
+export interface IAddAllCategoriesAction {
+  type: 'ADD_ALL_CATEGORIES',
+  categories: Category[]
+}
+
+export interface IAddNewCategoryAction {
+  type: 'ADD_CATEGORY',
+  category: Category
+}
+
+export interface IAddRandomWordCollectionsAction {
+  type: 'ADD_ALL_COLLECTIONS',
+  collections: RandomWordCollection[]
+}
+
+export interface IAddQuestionTemplatesAction {
+  type: 'ADD_ALL_TEMPLATES',
+  templates: string[]
+}
+
+export interface IAddSecretSauceAction {
+  type: 'ADD_SECRETE_SAUSE',
+  secretSauce: string[]
+}
+
+export interface IAddCurrentBrainstormAction {
+  type: 'ADD_CURRENT_BRAINSTORM',
+  currentBrainstorm: Brainstorm
+}
+
+export interface IRemoveCurrentBrainstormAction {
+  type: 'REMOVE_CURRENT_BRAINSTORM'
+}
+
+export interface IAddChosenWordAction {
+  type: 'ADD_WORD',
+  chosenWord: string
+}
+
+export interface IRemoveChosenWordAction {
+  type: 'REMOVE_WORD',
+  chosenWord: string
+}
+
+export interface IAddInsightAction {
+  type: 'ADD_INSIGHT',
+  insight: Insight
+}
+
+export interface IAddQueryAction {
+  type: 'ADD_QUERY',
+  query: string
+}
+
+export interface IRemoveQueryAction {
+  type: 'REMOVE_QUERY'
+}
+
+export interface IAddFilterAction {
+  type: 'ADD_FILTER',
+  filter: string
+}
+
+export interface IRemoveFilterAction {
+  type: 'REMOVE_FILTER'
+}
+
+export interface IEndTimeAction {
+  type: 'END_TIME'
+}
+
+export interface IReverseTimeAction {
+  type: 'REVERSE_TIME'
+}
+
+export interface IEndInstructionsAction {
+  type: 'END_INSTRUCTIONS'
+}
+
+export interface IReverseInstructionsAction {
+  type: 'REVERSE_INSTRUCTIONS'
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -25,7 +25,7 @@ export interface Brainstorm {
   question: string,
   idea: string,
   action: string,
-  isGenius: string,
+  isGenius: boolean,
   categories: number[]
 }
 
@@ -49,18 +49,14 @@ export interface randomWordCollection {
   [key: string]: WordContext
 }
 
-export interface ActionObject {
-  type:string,
-  [key: string]: any
-}
-
 export interface AppStore {
   user: UserLoginReceived,
   allBrainstorms: Brainstorm[],
+  actions: string[],
   categories: Category[],
-  randomWordCollections: randomWordCollection[],
-  questionTemplates: string[],
-  secretSauce: string[],
+  readonly randomWordCollections: randomWordCollection[],
+  readonly questionTemplates: string[],
+  readonly secretSauce: string[],
   currentBrainstorm: Brainstorm,
   chosenWords: string[],
   insights: Insight[],
@@ -68,4 +64,11 @@ export interface AppStore {
   filter: string,
   timeEnded: boolean,
   instructionsEnded: boolean
+}
+
+// ACTIONS OBJECTS
+
+export interface ActionObject {
+  type: string,
+  [key: string]: any
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -29,7 +29,7 @@ export interface Brainstorm {
   idea: string,
   action: string,
   isGenius: boolean,
-  categories: number[]
+  categories: Category[]
 }
 
 export interface Category {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -18,7 +18,10 @@ export interface UserSignupPosting {
   id?: number
 }
 
-// REDUX STORE INTERFACES
+export interface Action {
+  id?: number,
+  name: string
+}
 
 export interface Brainstorm {
   id?: number,
@@ -52,7 +55,7 @@ export interface randomWordCollection {
 export interface AppStore {
   user: UserLoginReceived,
   allBrainstorms: Brainstorm[],
-  actions: string[],
+  actions: Action[],
   categories: Category[],
   readonly randomWordCollections: randomWordCollection[],
   readonly questionTemplates: string[],

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -48,7 +48,7 @@ export interface WordContext {
   connectedWord: string[]
 }
 
-export interface randomWordCollection {
+export interface RandomWordCollection {
   [key: string]: WordContext
 }
 
@@ -57,7 +57,7 @@ export interface AppStore {
   allBrainstorms: Brainstorm[],
   actions: Action[],
   categories: Category[],
-  readonly randomWordCollections: randomWordCollection[],
+  readonly randomWordCollections: RandomWordCollection[],
   readonly questionTemplates: string[],
   readonly secretSauce: string[],
   currentBrainstorm: Brainstorm,

--- a/src/redux/actions/actions.test.ts
+++ b/src/redux/actions/actions.test.ts
@@ -335,3 +335,25 @@ describe("filter", () => {
 });
 
 
+describe("timeEnded", () => {
+  it("should return object with a type of END_TIME when endTime is called", () => {
+    const expected: interfaces.IEndTimeAction = {
+      type: 'END_TIME'
+    };
+
+    const result = actions.endTime()
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return object with a type of REVERSE_TIME when reverseTime is called", () => {
+    const expected: interfaces.IReverseTimeAction = {
+      type: 'REVERSE_TIME'
+    };
+
+    const result = actions.reverseTime()
+
+    expect(result).toEqual(expected);
+  });
+});
+

--- a/src/redux/actions/actions.test.ts
+++ b/src/redux/actions/actions.test.ts
@@ -357,3 +357,24 @@ describe("timeEnded", () => {
   });
 });
 
+describe("instructionsEnded", () => {
+  it("should return object with a type of END_INSTRUCTIONS when endInstructions is called", () => {
+    const expected: interfaces.IEndInstructionsAction = {
+      type: 'END_INSTRUCTIONS'
+    };
+
+    const result = actions.endInstructions()
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return object with a type of REVERSE_INSTRUCTIONS when reverseInstructions is called", () => {
+    const expected: interfaces.IReverseInstructionsAction = {
+      type: 'REVERSE_INSTRUCTIONS'
+    };
+
+    const result = actions.reverseInstructions()
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/redux/actions/actions.test.ts
+++ b/src/redux/actions/actions.test.ts
@@ -117,3 +117,37 @@ describe("allBrainstorms", () => {
   });
 });
 
+describe("categories", () => {
+  it("should return object with a type of ADD_ALL_CATEGORIES when addAllCategories is called", () => {
+    const categoiesMock: interfaces.Category[] = [{
+      id: 1,
+      name: 'Tech'
+    }];
+
+    const expected: interfaces.IAddAllCategoriesAction = {
+      type: 'ADD_ALL_CATEGORIES',
+      categories: categoiesMock
+    };
+
+    const result = actions.addAllCategories(categoiesMock)
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return object with a type of ADD_CATEGORY when addNewCategory is called", () => {
+    const categoryMock: interfaces.Category = {
+      id: 1,
+      name: 'Tech'
+    };
+
+    const expected: interfaces.IAddNewCategoryAction = {
+      type: 'ADD_CATEGORY',
+      category: categoryMock
+    };
+
+    const result = actions.addNewCategory(categoryMock)
+
+    expect(result).toEqual(expected);
+  });
+});
+

--- a/src/redux/actions/actions.test.ts
+++ b/src/redux/actions/actions.test.ts
@@ -151,3 +151,57 @@ describe("categories", () => {
   });
 });
 
+describe("randomWordCollections", () => {
+  it("should return object with a type of ADD_ALL_COLLECTIONS when addRandomWordCollections is called", () => {
+    const collectionsMock: interfaces.RandomWordCollection[] = [{
+      'goose': {
+        type: 'noun',
+        connectedWord: ['duck', 'happy', 'dinner']
+      }
+    }];
+
+    const expected: interfaces.IAddRandomWordCollectionsAction = {
+      type: 'ADD_ALL_COLLECTIONS',
+      collections: collectionsMock
+    };
+
+    const result = actions.addRandomWordCollections(collectionsMock)
+
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("questionTemplates", () => {
+  it("should return object with a type of ADD_ALL_COLLECTIONS when addQuestionTemplates is called", () => {
+    const questionsMock: string[] = [
+      'What does <sth> do with <sec>?'
+    ];
+
+    const expected: interfaces.IAddQuestionTemplatesAction = {
+      type: 'ADD_ALL_TEMPLATES',
+      templates: questionsMock
+    };
+
+    const result = actions.addQuestionTemplates(questionsMock)
+
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("secretSauce", () => {
+  it("should return object with a type of ADD_SECRETE_SAUSE when addSecretSauce is called", () => {
+    const secretSauceMock: string[] = [
+      'winter', 'development'
+    ];
+
+    const expected: interfaces.IAddSecretSauceAction = {
+      type: 'ADD_SECRETE_SAUSE',
+      secretSauce: secretSauceMock
+    };
+
+    const result = actions.addSecretSauce(secretSauceMock)
+
+    expect(result).toEqual(expected);
+  });
+});
+

--- a/src/redux/actions/actions.test.ts
+++ b/src/redux/actions/actions.test.ts
@@ -30,3 +30,37 @@ describe("user", () => {
   });
 });
 
+describe("actions", () => {
+  it("should return object with a type of ADD_ALL_ACTIONS when addAllActions is called", () => {
+    const actionsMock: interfaces.Action[] = [{
+      id: 1,
+      name: 'Build an app'
+    }];
+
+    const expected: interfaces.IAddAllActionsAction = {
+      type: 'ADD_ALL_ACTIONS',
+      actions: actionsMock
+    };
+
+    const result = actions.addAllActions(actionsMock)
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return object with a type of ADD_NEW_ACTION when addNewAction is called", () => {
+    const actionMock: interfaces.Action = {
+      id: 1,
+      name: 'Build an app'
+    };
+
+    const expected: interfaces.IAddNewActionAction = {
+      type: 'ADD_NEW_ACTION',
+      action: actionMock
+    };
+
+    const result = actions.addNewAction(actionMock)
+
+    expect(result).toEqual(expected);
+  });
+});
+

--- a/src/redux/actions/actions.test.ts
+++ b/src/redux/actions/actions.test.ts
@@ -1,0 +1,32 @@
+import * as interfaces from '../../interfaces';
+import * as actions from './';
+
+describe("user", () => {
+  it("should return object with a type of ADD_USER when addUser is called", () => {
+    const userMock: interfaces.UserLoginReceived = {
+      id: 1,
+      firstName: 'Ray',
+      lastName: 'Z'
+    };
+
+    const expected: interfaces.IAddUserAction = {
+      type: 'ADD_USER',
+      user: userMock
+    };
+
+    const result = actions.addUser(userMock);
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return object with a type of LOG_OUT_USER when logOutUser is called", () => {
+    const expected: interfaces.ILogoutUserAction = {
+      type: 'LOG_OUT_USER'
+    };
+
+    const result = actions.logOutUser();
+
+    expect(result).toEqual(expected);
+  });
+});
+

--- a/src/redux/actions/actions.test.ts
+++ b/src/redux/actions/actions.test.ts
@@ -284,3 +284,28 @@ describe("insights", () => {
   });
 });
 
+describe("query", () => {
+  it("should return object with a type of ADD_QUERY when addQuery is called", () => {
+    const queryMock: string = 'App';
+
+    const expected: interfaces.IAddQueryAction = {
+      type: 'ADD_QUERY',
+      query: queryMock
+    };
+
+    const result = actions.addQuery(queryMock)
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return object with a type of REMOVE_QUERY when removeQuery is called", () => {
+    const expected: interfaces.IRemoveQueryAction = {
+      type: 'REMOVE_QUERY'
+    };
+
+    const result = actions.removeQuery()
+
+    expect(result).toEqual(expected);
+  });
+});
+

--- a/src/redux/actions/actions.test.ts
+++ b/src/redux/actions/actions.test.ts
@@ -309,3 +309,29 @@ describe("query", () => {
   });
 });
 
+describe("filter", () => {
+  it("should return object with a type of ADD_FILTER when addFilter is called", () => {
+    const filterMock: string = 'Tech';
+
+    const expected: interfaces.IAddFilterAction = {
+      type: 'ADD_FILTER',
+      filter: filterMock
+    };
+
+    const result = actions.addFilter(filterMock)
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return object with a type of REMOVE_FILTER when removeFilter is called", () => {
+    const expected: interfaces.IRemoveFilterAction = {
+      type: 'REMOVE_FILTER'
+    };
+
+    const result = actions.removeFilter()
+
+    expect(result).toEqual(expected);
+  });
+});
+
+

--- a/src/redux/actions/actions.test.ts
+++ b/src/redux/actions/actions.test.ts
@@ -265,3 +265,22 @@ describe("chosenWords", () => {
   });
 });
 
+describe("insights", () => {
+  it("should return object with a type of ADD_INSIGHT when addInsight is called", () => {
+    const insightMock: interfaces.Insight = {
+      id: 1,
+      question: 'What?',
+      answers: ['Doing']
+    };
+
+    const expected: interfaces.IAddInsightAction = {
+      type: 'ADD_INSIGHT',
+      insight: insightMock
+    };
+
+    const result = actions.addInsight(insightMock)
+
+    expect(result).toEqual(expected);
+  });
+});
+

--- a/src/redux/actions/actions.test.ts
+++ b/src/redux/actions/actions.test.ts
@@ -205,3 +205,35 @@ describe("secretSauce", () => {
   });
 });
 
+describe("currentBrainstorm", () => {
+  it("should return object with a type of ADD_CURRENT_BRAINSTORM when addCurrentBrainstorm is called", () => {
+    const currentBrainstormMock: interfaces.Brainstorm = {
+      id: 1,
+      question: 'What?',
+      idea: 'Idea',
+      action: 'Build',
+      categories: [{id: 1, name: "Tech"}],
+      isGenius: true
+    };
+
+    const expected: interfaces.IAddCurrentBrainstormAction = {
+      type: 'ADD_CURRENT_BRAINSTORM',
+      currentBrainstorm: currentBrainstormMock
+    };
+
+    const result = actions.addCurrentBrainstorm(currentBrainstormMock)
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return object with a type of REMOVE_CURRENT_BRAINSTORM when removeCurrentBrainstorm is called", () => {
+    const expected: interfaces.IRemoveCurrentBrainstormAction = {
+      type: 'REMOVE_CURRENT_BRAINSTORM'
+    };
+
+    const result = actions.removeCurrentBrainstorm()
+
+    expect(result).toEqual(expected);
+  });
+});
+

--- a/src/redux/actions/actions.test.ts
+++ b/src/redux/actions/actions.test.ts
@@ -64,3 +64,56 @@ describe("actions", () => {
   });
 });
 
+describe("allBrainstorms", () => {
+  it("should return object with a type of ADD_ALL_BRAINSTORMS when addAllBrainstorms is called", () => {
+    const brainstormsMock: interfaces.Brainstorm[] = [{
+      id: 1,
+      question: 'What?',
+      idea: 'Idea',
+      action: 'Build',
+      categories: [{id: 1, name: "Tech"}],
+      isGenius: true
+    }];
+
+    const expected: interfaces.IAddAllBrainstormsAction = {
+      type: 'ADD_ALL_BRAINSTORMS',
+      brainstorms: brainstormsMock
+    };
+
+    const result = actions.addAllBrainstorms(brainstormsMock)
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return object with a type of ADD_BRAINSTORM when addNewBrainstorm is called", () => {
+    const brainstormMock: interfaces.Brainstorm = {
+      id: 1,
+      question: 'What?',
+      idea: 'Idea',
+      action: 'Build',
+      categories: [{id: 1, name: "Tech"}],
+      isGenius: true
+    };
+
+    const expected: interfaces.IAddNewBrainstormAction = {
+      type: 'ADD_BRAINSTORM',
+      brainstorm: brainstormMock
+    };
+
+    const result = actions.addNewBrainstorm(brainstormMock)
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return object with a type of DELETE_BRAINSTORM when deleteBrainstorm is called", () => {
+    const expected: interfaces.IDeleteBrainstormAction = {
+      type: 'DELETE_BRAINSTORM',
+      id: 1
+    };
+
+    const result = actions.deleteBrainstorm(1)
+
+    expect(result).toEqual(expected);
+  });
+});
+

--- a/src/redux/actions/actions.test.ts
+++ b/src/redux/actions/actions.test.ts
@@ -237,3 +237,31 @@ describe("currentBrainstorm", () => {
   });
 });
 
+describe("chosenWords", () => {
+  it("should return object with a type of ADD_WORD when addChosenWord is called", () => {
+    const wordMock: string = 'Elephant';
+
+    const expected: interfaces.IAddChosenWordAction = {
+      type: 'ADD_WORD',
+      chosenWord: wordMock
+    };
+
+    const result = actions.addChosenWord(wordMock)
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return object with a type of REMOVE_WORD when removeChosenWord is called", () => {
+    const wordMock: string = 'Elephant';
+
+    const expected: interfaces.IRemoveChosenWordAction = {
+      type: 'REMOVE_WORD',
+      chosenWord: wordMock
+    };
+
+    const result = actions.removeChosenWord(wordMock)
+
+    expect(result).toEqual(expected);
+  });
+});
+

--- a/src/redux/actions/index.ts
+++ b/src/redux/actions/index.ts
@@ -1,11 +1,145 @@
-import { UserLoginReceived, ActionObject } from '../../interfaces';
+import {
+  Action,
+  Category,
+  Brainstorm,
+  UserLoginReceived,
+  RandomWordCollection,
+  Insight,
+  ActionObject
+} from '../../interfaces';
 
+// user reducer action creators
 export const addUser = (user: UserLoginReceived): ActionObject => ({
   type: 'ADD_USER',
   user: user
 });
 
-export const logOutUser = () => ({
+export const logOutUser = (): ActionObject => ({
   type: 'LOG_OUT_USER',
 });
 
+// actions reducer action creators
+export const addAllActions = (actions: Action[]): ActionObject => ({
+  type: 'ADD_ALL_ACTIONS',
+  actions: actions
+});
+
+export const addNewAction = (action: Action): ActionObject => ({
+  type: 'ADD_NEW_ACTIONS',
+  action: action
+});
+
+// allBrainstorms reducer action creators
+export const addAllBrainstorms = (brainstorms: Brainstorm[]): ActionObject => ({
+  type: 'ADD_ALL_BRAINSTORMS',
+  brainstorms: brainstorms
+});
+
+export const addNewBrainstorm = (brainstorm: Brainstorm): ActionObject => ({
+  type: 'ADD_BRAINSTORM',
+  brainstorm: brainstorm
+});
+
+export const deleteBrainstorm = (id: number): ActionObject => ({
+  type: 'DELETE_BRAINSTORM',
+  id: id
+});
+
+// categories reducer action creators
+export const addAllCategories = (categories: Category[]): ActionObject => ({
+  type: 'ADD_ALL_CATEGORIES',
+  categories: categories
+});
+
+export const addNewCategory = (category: Category): ActionObject => ({
+  type: 'ADD_CATEGORY',
+  category: category
+});
+
+export const deleteCategory = (id: number): ActionObject => ({
+  type: 'DELETE_BRAINSTORM',
+  id: id
+});
+
+// randomWordCollections reducer action creators
+export const addRandomWordCollections = (collections: RandomWordCollection[]): ActionObject => ({
+  type: 'ADD_ALL_COLLECTIONS',
+  collections: collections
+});
+
+// questionTemplates reducer action creators
+export const addQuestionTemplates = (templates: string[]): ActionObject => ({
+  type: 'ADD_ALL_TEMPLATES',
+  templates: templates
+});
+
+// secretSauce reducer action creators
+export const addSecretSauce = (secretSauce: string[]): ActionObject => ({
+  type: 'ADD_ALL_TEMPLATES',
+  secretSauce: secretSauce
+});
+
+// currentBrainstorm reducer action creators
+export const addCurrentBrainstorm = (currentBrainstorm: Brainstorm): ActionObject => ({
+  type: 'ADD_CURRENT_BRAINSTORM',
+  currentBrainstorm: currentBrainstorm
+});
+
+export const removeCurrentBrainstorm = (): ActionObject => ({
+  type: 'REMOVE_CURRENT_BRAINSTORM'
+});
+
+// chosenWords reducer action creators
+export const addChosenWord = (chosenWord: string): ActionObject => ({
+  type: 'ADD_WORD',
+  chosenWord: chosenWord
+});
+
+export const removeChosenWord = (chosenWord: string): ActionObject => ({
+  type: 'REMOVE_WORD',
+  chosenWord: chosenWord
+});
+
+// insights reducer action creators
+export const addInsight = (insight: Insight): ActionObject => ({
+  type: 'ADD_INSIGHT',
+  insight: insight
+});
+
+// query reducer action creators
+export const addQuery = (query: string): ActionObject => ({
+  type: 'ADD_QUERY',
+  query: query
+});
+
+export const removeQuery = (): ActionObject => ({
+  type: 'REMOVE_QUERY'
+});
+
+// filter reducer action creators
+export const addFilter = (filter: string): ActionObject => ({
+  type: 'ADD_FILTER',
+  filter: filter
+});
+
+export const removeFilter = (): ActionObject => ({
+  type: 'REMOVE_FILTER'
+});
+
+// timeEnded reducer action creators
+export const endTime = (): ActionObject => ({
+  type: 'END_TIME'
+});
+
+export const clearTime = (): ActionObject => ({
+  type: 'CLEAR_TIME'
+});
+
+// instructionsEnded reducer action creators
+export const endInstructions = (): ActionObject => ({
+  type: 'END_INSTRUCTIONS'
+});
+
+export const clearInstructions = (): ActionObject => ({
+  type: 'CLEAR_INSTRUCTIONS'
+});

--- a/src/redux/actions/index.ts
+++ b/src/redux/actions/index.ts
@@ -5,141 +5,161 @@ import {
   UserLoginReceived,
   RandomWordCollection,
   Insight,
-  ActionObject
-} from '../../interfaces';
+  ActionObject,
+  IAddUserAction,
+  ILogoutUserAction,
+  IAddAllActionsAction,
+  IAddNewActionAction,
+  IAddAllBrainstormsAction,
+  IAddNewBrainstormAction,
+  IDeleteBrainstormAction,
+  IAddAllCategoriesAction,
+  IAddNewCategoryAction,
+  IAddRandomWordCollectionsAction,
+  IAddQuestionTemplatesAction,
+  IAddSecretSauceAction,
+  IAddCurrentBrainstormAction,
+  IRemoveCurrentBrainstormAction,
+  IAddChosenWordAction,
+  IRemoveChosenWordAction,
+  IAddInsightAction,
+  IAddQueryAction,
+  IRemoveQueryAction,
+  IAddFilterAction,
+  IRemoveFilterAction,
+  IEndTimeAction,
+  IReverseTimeAction,
+  IEndInstructionsAction,
+  IReverseInstructionsAction
+} from 'interfaces';
 
 // user reducer action creators
-export const addUser = (user: UserLoginReceived): ActionObject => ({
+export const addUser = (user: UserLoginReceived): IAddUserAction => ({
   type: 'ADD_USER',
   user: user
 });
 
-export const logOutUser = (): ActionObject => ({
+export const logOutUser = (): ILogoutUserAction => ({
   type: 'LOG_OUT_USER',
 });
 
 // actions reducer action creators
-export const addAllActions = (actions: Action[]): ActionObject => ({
+export const addAllActions = (actions: Action[]): IAddAllActionsAction => ({
   type: 'ADD_ALL_ACTIONS',
   actions: actions
 });
 
-export const addNewAction = (action: Action): ActionObject => ({
-  type: 'ADD_NEW_ACTIONS',
+export const addNewAction = (action: Action): IAddNewActionAction => ({
+  type: 'ADD_NEW_ACTION',
   action: action
 });
 
 // allBrainstorms reducer action creators
-export const addAllBrainstorms = (brainstorms: Brainstorm[]): ActionObject => ({
+export const addAllBrainstorms = (brainstorms: Brainstorm[]): IAddAllBrainstormsAction => ({
   type: 'ADD_ALL_BRAINSTORMS',
   brainstorms: brainstorms
 });
 
-export const addNewBrainstorm = (brainstorm: Brainstorm): ActionObject => ({
+export const addNewBrainstorm = (brainstorm: Brainstorm): IAddNewBrainstormAction => ({
   type: 'ADD_BRAINSTORM',
   brainstorm: brainstorm
 });
 
-export const deleteBrainstorm = (id: number): ActionObject => ({
+export const deleteBrainstorm = (id: number): IDeleteBrainstormAction => ({
   type: 'DELETE_BRAINSTORM',
   id: id
 });
 
 // categories reducer action creators
-export const addAllCategories = (categories: Category[]): ActionObject => ({
+export const addAllCategories = (categories: Category[]): IAddAllCategoriesAction => ({
   type: 'ADD_ALL_CATEGORIES',
   categories: categories
 });
 
-export const addNewCategory = (category: Category): ActionObject => ({
+export const addNewCategory = (category: Category): IAddNewCategoryAction => ({
   type: 'ADD_CATEGORY',
   category: category
 });
 
-export const deleteCategory = (id: number): ActionObject => ({
-  type: 'DELETE_BRAINSTORM',
-  id: id
-});
-
 // randomWordCollections reducer action creators
-export const addRandomWordCollections = (collections: RandomWordCollection[]): ActionObject => ({
+export const addRandomWordCollections = (collections: RandomWordCollection[]): IAddRandomWordCollectionsAction => ({
   type: 'ADD_ALL_COLLECTIONS',
   collections: collections
 });
 
 // questionTemplates reducer action creators
-export const addQuestionTemplates = (templates: string[]): ActionObject => ({
+export const addQuestionTemplates = (templates: string[]): IAddQuestionTemplatesAction => ({
   type: 'ADD_ALL_TEMPLATES',
   templates: templates
 });
 
 // secretSauce reducer action creators
-export const addSecretSauce = (secretSauce: string[]): ActionObject => ({
-  type: 'ADD_ALL_TEMPLATES',
+export const addSecretSauce = (secretSauce: string[]): IAddSecretSauceAction => ({
+  type: 'ADD_SECRETE_SAUSE',
   secretSauce: secretSauce
 });
 
 // currentBrainstorm reducer action creators
-export const addCurrentBrainstorm = (currentBrainstorm: Brainstorm): ActionObject => ({
+export const addCurrentBrainstorm = (currentBrainstorm: Brainstorm): IAddCurrentBrainstormAction => ({
   type: 'ADD_CURRENT_BRAINSTORM',
   currentBrainstorm: currentBrainstorm
 });
 
-export const removeCurrentBrainstorm = (): ActionObject => ({
+export const removeCurrentBrainstorm = (): IRemoveCurrentBrainstormAction => ({
   type: 'REMOVE_CURRENT_BRAINSTORM'
 });
 
 // chosenWords reducer action creators
-export const addChosenWord = (chosenWord: string): ActionObject => ({
+export const addChosenWord = (chosenWord: string): IAddChosenWordAction => ({
   type: 'ADD_WORD',
   chosenWord: chosenWord
 });
 
-export const removeChosenWord = (chosenWord: string): ActionObject => ({
+export const removeChosenWord = (chosenWord: string): IRemoveChosenWordAction => ({
   type: 'REMOVE_WORD',
   chosenWord: chosenWord
 });
 
 // insights reducer action creators
-export const addInsight = (insight: Insight): ActionObject => ({
+export const addInsight = (insight: Insight): IAddInsightAction => ({
   type: 'ADD_INSIGHT',
   insight: insight
 });
 
 // query reducer action creators
-export const addQuery = (query: string): ActionObject => ({
+export const addQuery = (query: string): IAddQueryAction => ({
   type: 'ADD_QUERY',
   query: query
 });
 
-export const removeQuery = (): ActionObject => ({
+export const removeQuery = (): IRemoveQueryAction => ({
   type: 'REMOVE_QUERY'
 });
 
 // filter reducer action creators
-export const addFilter = (filter: string): ActionObject => ({
+export const addFilter = (filter: string): IAddFilterAction => ({
   type: 'ADD_FILTER',
   filter: filter
 });
 
-export const removeFilter = (): ActionObject => ({
+export const removeFilter = (): IRemoveFilterAction => ({
   type: 'REMOVE_FILTER'
 });
 
 // timeEnded reducer action creators
-export const endTime = (): ActionObject => ({
+export const endTime = (): IEndTimeAction => ({
   type: 'END_TIME'
 });
 
-export const clearTime = (): ActionObject => ({
-  type: 'CLEAR_TIME'
+export const reverseTime = (): IReverseTimeAction => ({
+  type: 'REVERSE_TIME'
 });
 
 // instructionsEnded reducer action creators
-export const endInstructions = (): ActionObject => ({
+export const endInstructions = (): IEndInstructionsAction => ({
   type: 'END_INSTRUCTIONS'
 });
 
-export const clearInstructions = (): ActionObject => ({
-  type: 'CLEAR_INSTRUCTIONS'
+export const reverseInstructions = (): IReverseInstructionsAction => ({
+  type: 'REVERSE_INSTRUCTIONS'
 });

--- a/src/redux/actions/index.ts
+++ b/src/redux/actions/index.ts
@@ -5,7 +5,6 @@ import {
   UserLoginReceived,
   RandomWordCollection,
   Insight,
-  ActionObject,
   IAddUserAction,
   ILogoutUserAction,
   IAddAllActionsAction,

--- a/src/redux/reducers/actions/actions.test.ts
+++ b/src/redux/reducers/actions/actions.test.ts
@@ -1,0 +1,30 @@
+import actionsReducer from './actions';
+import { ActionObject } from 'interfaces';
+
+type emptyArray = [];
+
+describe('actionsReducer', () => {
+  it("should return initial value", () => {
+    const expected: emptyArray = [];
+    const result = actionsReducer(undefined, {type: '', actions: undefined });
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return the array of actions words if type of action is ADD_ACTIONS", () => {
+    const mockActions: string[] = [
+      'Build an app'
+    ];
+
+    const mockAction: ActionObject = {
+      type: 'ADD_ACTIONS',
+      actions: mockActions
+    };
+
+    const expected: string[] = mockActions;
+
+    const result: string[] = actionsReducer(undefined, mockAction);
+
+    expect(result).toEqual(expected);
+  })
+});

--- a/src/redux/reducers/actions/actions.test.ts
+++ b/src/redux/reducers/actions/actions.test.ts
@@ -1,30 +1,53 @@
 import actionsReducer from './actions';
-import { ActionObject } from 'interfaces';
+import { Action, ActionObject, IAddAllActionsAction, IAddNewActionAction } from 'interfaces';
 
 type emptyArray = [];
 
 describe('actionsReducer', () => {
   it("should return initial value", () => {
+    const mockAction: ActionObject = {
+      type: '',
+      actions: undefined
+    };
     const expected: emptyArray = [];
-    const result = actionsReducer(undefined, {type: '', actions: undefined });
+    const result = actionsReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
   });
 
-  it("should return the array of actions words if type of action is ADD_ACTIONS", () => {
-    const mockActions: string[] = [
-      'Build an app'
-    ];
+  it("should return the array of action words if type of action is ADD_ALL_ACTIONS", () => {
+    const mockActions: Action[] = [{
+      id: 1,
+      name: 'Build an app'
+    }];
 
-    const mockAction: ActionObject = {
-      type: 'ADD_ACTIONS',
+    const mockAction: IAddAllActionsAction = {
+      type: 'ADD_ALL_ACTIONS',
       actions: mockActions
     };
 
-    const expected: string[] = mockActions;
+    const expected: Action[] = mockActions;
 
-    const result: string[] = actionsReducer(undefined, mockAction);
+    const result = actionsReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
-  })
+  });
+
+  it("should return the array with added action if type of action is ADD_NEW_ACTION", () => {
+    const mockBrainstormAction: Action = {
+      id: 1,
+      name: 'Build an app'
+    };
+
+    const mockAction: IAddNewActionAction = {
+      type: 'ADD_NEW_ACTION',
+      action: mockBrainstormAction
+    };
+
+    const expected: Action[] = [mockBrainstormAction];
+
+    const result = actionsReducer([], mockAction);
+
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/redux/reducers/actions/actions.ts
+++ b/src/redux/reducers/actions/actions.ts
@@ -4,8 +4,10 @@ type state = string[] | [ ];
 
 const actions = (state: state = [ ], action: ActionObject) => {
   switch(action.type) {
-    case 'ADD_ACTIONS':
+    case 'ADD_ALL_ACTIONS':
       return action.actions;
+    case 'ADD_NEW_ACTION':
+      return [...state, action.action];
     default:
       return state;
   }

--- a/src/redux/reducers/actions/actions.ts
+++ b/src/redux/reducers/actions/actions.ts
@@ -1,0 +1,14 @@
+import { ActionObject } from 'interfaces';
+
+type state = string[] | [ ];
+
+const actions = (state: state = [ ], action: ActionObject) => {
+  switch(action.type) {
+    case 'ADD_ACTIONS':
+      return action.actions;
+    default:
+      return state;
+  }
+}
+
+export default actions;

--- a/src/redux/reducers/allBrainstorms/allBrainstorms.test.ts
+++ b/src/redux/reducers/allBrainstorms/allBrainstorms.test.ts
@@ -1,34 +1,93 @@
 import allBrainstormsReducer from './allBrainstorms';
-import { ActionObject, Brainstorm } from 'interfaces';
+import { ActionObject, Brainstorm, IAddAllBrainstormsAction, IAddNewBrainstormAction, IDeleteBrainstormAction } from 'interfaces';
 
 type emptyArray = [ ];
 
 describe('allBrainstormsReducer', () => {
   it("should return initial value", () => {
+    const mockAction: ActionObject = {
+      type: '',
+      brainstorms: undefined
+    }
+
     const expected: emptyArray = [ ];
-    const result = allBrainstormsReducer(undefined, {type: '', brainstorms: undefined });
+    const result = allBrainstormsReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
   });
 
-  it("should return the array of brainstorms if type of action is ADD_BRAINSTORMS", () => {
+  it("should return the array of brainstorms if type of action is ADD_ALL_BRAINSTORMS", () => {
     const mockBrainstorms: Brainstorm[] = [{
+      id: 1,
       question: 'What?',
       idea: 'Idea',
       action: 'Do sth',
       isGenius: true,
-      categories: [1, 2]
+      categories: [{
+        id: 1,
+        name: 'Tech'
+      }]
     }];
 
-    const mockAction: ActionObject = {
-      type: 'ADD_BRAINSTORMS',
+    const mockAction: IAddAllBrainstormsAction = {
+      type: 'ADD_ALL_BRAINSTORMS',
       brainstorms: mockBrainstorms
     };
 
     const expected: Brainstorm[] = mockBrainstorms;
 
-    const result: Brainstorm[] = allBrainstormsReducer(undefined, mockAction);
+    const result = allBrainstormsReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
-  })
+  });
+
+  it("should return the array with new brainstorm if type of action is ADD_BRAINSTORM", () => {
+    const mockBrainstorm: Brainstorm = {
+      id: 1,
+      question: 'What?',
+      idea: 'Idea',
+      action: 'Do sth',
+      isGenius: true,
+      categories: [{
+        id: 1,
+        name: 'Tech'
+      }]
+    };
+
+    const mockAction: IAddNewBrainstormAction = {
+      type: 'ADD_BRAINSTORM',
+      brainstorm: mockBrainstorm
+    };
+
+    const expected: Brainstorm[] = [ mockBrainstorm ];
+
+    const result = allBrainstormsReducer([], mockAction);
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return the array without a chosen brainstorm if type of action is DELETE_BRAINSTORM", () => {
+    const mockAction: IDeleteBrainstormAction = {
+      type: 'DELETE_BRAINSTORM',
+      id: 1
+    };
+
+    const mockState: Brainstorm[] = [{
+      id: 1,
+      question: 'What?',
+      idea: 'Idea',
+      action: 'Do sth',
+      isGenius: true,
+      categories: [{
+        id: 1,
+        name: 'Tech'
+      }]
+    }];
+
+    const expected: emptyArray = [];
+
+    const result = allBrainstormsReducer(mockState, mockAction);
+
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/redux/reducers/allBrainstorms/allBrainstorms.test.ts
+++ b/src/redux/reducers/allBrainstorms/allBrainstorms.test.ts
@@ -1,0 +1,34 @@
+import allBrainstormsReducer from './allBrainstorms';
+import { ActionObject, Brainstorm } from 'interfaces';
+
+type emptyArray = [ ];
+
+describe('allBrainstormsReducer', () => {
+  it("should return initial value", () => {
+    const expected: emptyArray = [ ];
+    const result = allBrainstormsReducer(undefined, {type: '', brainstorms: undefined });
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return the array of brainstorms if type of action is ADD_BRAINSTORMS", () => {
+    const mockBrainstorms: Brainstorm[] = [{
+      question: 'What?',
+      idea: 'Idea',
+      action: 'Do sth',
+      isGenius: true,
+      categories: [1, 2]
+    }];
+
+    const mockAction: ActionObject = {
+      type: 'ADD_BRAINSTORMS',
+      brainstorms: mockBrainstorms
+    };
+
+    const expected: Brainstorm[] = mockBrainstorms;
+
+    const result: Brainstorm[] = allBrainstormsReducer(undefined, mockAction);
+
+    expect(result).toEqual(expected);
+  })
+});

--- a/src/redux/reducers/allBrainstorms/allBrainstorms.ts
+++ b/src/redux/reducers/allBrainstorms/allBrainstorms.ts
@@ -4,8 +4,12 @@ type state = Brainstorm[] | [ ];
 
 const allBrainstorms = (state: state = [ ], action: ActionObject) => {
   switch(action.type) {
-    case 'ADD_BRAINSTORMS':
+    case 'ADD_ALL_BRAINSTORMS':
       return action.brainstorms;
+    case 'ADD_BRAINSTORM':
+      return [...state, action.brainstorm];
+    case 'DELETE_BRAINSTORM':
+      return state.filter(bs => bs.id !== action.id);
     default:
       return state;
   }

--- a/src/redux/reducers/allBrainstorms/allBrainstorms.ts
+++ b/src/redux/reducers/allBrainstorms/allBrainstorms.ts
@@ -1,0 +1,14 @@
+import { ActionObject, Brainstorm } from 'interfaces';
+
+type state = Brainstorm[] | [ ];
+
+const allBrainstorms = (state: state = [ ], action: ActionObject) => {
+  switch(action.type) {
+    case 'ADD_BRAINSTORMS':
+      return action.brainstorms;
+    default:
+      return state;
+  }
+}
+
+export default allBrainstorms;

--- a/src/redux/reducers/categories/categories.test.ts
+++ b/src/redux/reducers/categories/categories.test.ts
@@ -1,0 +1,31 @@
+import categoriesReducer from './categories';
+import { ActionObject, Category } from 'interfaces';
+
+type emptyArray = [ ];
+
+describe('categoriesReducer', () => {
+  it("should return initial value", () => {
+    const expected: emptyArray = [ ];
+    const result = categoriesReducer(undefined, {type: '', categories: undefined });
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return the array of categories if type of action is ADD_CATEGORIES", () => {
+    const mockCategories: Category[] = [{
+      id: 1,
+      name: 'Tech'
+    }];
+
+    const mockAction: ActionObject = {
+      type: 'ADD_CATEGORIES',
+      categories: mockCategories
+    };
+
+    const expected: Category[] = mockCategories;
+
+    const result: Category[] = categoriesReducer(undefined, mockAction);
+
+    expect(result).toEqual(expected);
+  })
+});

--- a/src/redux/reducers/categories/categories.test.ts
+++ b/src/redux/reducers/categories/categories.test.ts
@@ -1,24 +1,29 @@
 import categoriesReducer from './categories';
-import { ActionObject, Category } from 'interfaces';
+import { ActionObject, Category, IAddAllCategoriesAction, IAddNewCategoryAction } from 'interfaces';
 
 type emptyArray = [ ];
 
 describe('categoriesReducer', () => {
   it("should return initial value", () => {
+    const mockAction: ActionObject = {
+      type: '',
+      categories: undefined
+    };
+
     const expected: emptyArray = [ ];
-    const result = categoriesReducer(undefined, {type: '', categories: undefined });
+    const result = categoriesReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
   });
 
-  it("should return the array of categories if type of action is ADD_CATEGORIES", () => {
+  it("should return the array of categories if type of action is ADD_ALL_CATEGORIES", () => {
     const mockCategories: Category[] = [{
       id: 1,
       name: 'Tech'
     }];
 
-    const mockAction: ActionObject = {
-      type: 'ADD_CATEGORIES',
+    const mockAction: IAddAllCategoriesAction = {
+      type: 'ADD_ALL_CATEGORIES',
       categories: mockCategories
     };
 
@@ -27,5 +32,23 @@ describe('categoriesReducer', () => {
     const result: Category[] = categoriesReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
-  })
+  });
+
+  it("should return the array with added category if type of action is ADD_CATEGORY", () => {
+    const mockCategory: Category = {
+      id: 1,
+      name: 'Tech'
+    };
+
+    const mockAction: IAddNewCategoryAction = {
+      type: 'ADD_CATEGORY',
+      category: mockCategory
+    };
+
+    const expected: Category[] = [ mockCategory ];
+
+    const result: Category[] = categoriesReducer([], mockAction);
+
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/redux/reducers/categories/categories.ts
+++ b/src/redux/reducers/categories/categories.ts
@@ -4,8 +4,10 @@ type state = Category[ ] | [ ];
 
 const categories = (state: state = [ ], action: ActionObject) => {
   switch(action.type) {
-    case 'ADD_CATEGORIES':
+    case 'ADD_ALL_CATEGORIES':
       return action.categories;
+    case 'ADD_CATEGORY':
+      return [...state, action.category];
     default:
       return state;
   }

--- a/src/redux/reducers/categories/categories.ts
+++ b/src/redux/reducers/categories/categories.ts
@@ -1,0 +1,14 @@
+import { ActionObject, Category } from 'interfaces';
+
+type state = Category[ ] | [ ];
+
+const categories = (state: state = [ ], action: ActionObject) => {
+  switch(action.type) {
+    case 'ADD_CATEGORIES':
+      return action.categories;
+    default:
+      return state;
+  }
+}
+
+export default categories;

--- a/src/redux/reducers/chosenWords/chosenWords.test.ts
+++ b/src/redux/reducers/chosenWords/chosenWords.test.ts
@@ -1,22 +1,26 @@
 import chosenWordsReducer from './chosenWords';
-import { ActionObject } from 'interfaces';
+import { ActionObject, IAddChosenWordAction, IRemoveChosenWordAction } from 'interfaces';
 
 type emptyArray = [ ];
 
 describe('chosenWordsReducer', () => {
   it("should return initial value", () => {
+    const mockAction: ActionObject = {
+      type: '',
+      word: undefined
+    };
     const expected: emptyArray = [ ];
-    const result = chosenWordsReducer(undefined, {type: '', word: undefined });
+    const result = chosenWordsReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
   });
 
-  it("should return the array with a new chosen word if type of action is ADD_SELECTED_WORD", () => {
+  it("should return the array with a new chosen word if type of action is ADD_WORD", () => {
     const mockChosenWord: string = 'Bear';
 
-    const mockAction: ActionObject = {
-      type: 'ADD_SELECTED_WORD',
-      word: mockChosenWord
+    const mockAction: IAddChosenWordAction = {
+      type: 'ADD_WORD',
+      chosenWord: mockChosenWord
     };
 
     const expected: string[] = [mockChosenWord];
@@ -24,5 +28,20 @@ describe('chosenWordsReducer', () => {
     const result: string[] = chosenWordsReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
-  })
+  });
+
+  it("should return the array without a chosen word if type of action is REMOVE_WORD", () => {
+    const mockChosenWord: string = 'Bear';
+
+    const mockAction: IRemoveChosenWordAction = {
+      type: 'REMOVE_WORD',
+      chosenWord: mockChosenWord
+    };
+
+    const expected: emptyArray = [ ];
+
+    const result: string[] = chosenWordsReducer(['Bear'], mockAction);
+
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/redux/reducers/chosenWords/chosenWords.test.ts
+++ b/src/redux/reducers/chosenWords/chosenWords.test.ts
@@ -1,0 +1,28 @@
+import chosenWordsReducer from './chosenWords';
+import { ActionObject } from 'interfaces';
+
+type emptyArray = [ ];
+
+describe('chosenWordsReducer', () => {
+  it("should return initial value", () => {
+    const expected: emptyArray = [ ];
+    const result = chosenWordsReducer(undefined, {type: '', word: undefined });
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return the array with a new chosen word if type of action is ADD_SELECTED_WORD", () => {
+    const mockChosenWord: string = 'Bear';
+
+    const mockAction: ActionObject = {
+      type: 'ADD_SELECTED_WORD',
+      word: mockChosenWord
+    };
+
+    const expected: string[] = [mockChosenWord];
+
+    const result: string[] = chosenWordsReducer(undefined, mockAction);
+
+    expect(result).toEqual(expected);
+  })
+});

--- a/src/redux/reducers/chosenWords/chosenWords.ts
+++ b/src/redux/reducers/chosenWords/chosenWords.ts
@@ -1,0 +1,14 @@
+import { ActionObject } from 'interfaces';
+
+type state = string[ ] | [ ];
+
+const chosenWords = (state: state = [ ], action: ActionObject) => {
+  switch(action.type) {
+    case 'ADD_SELECTED_WORD':
+      return [...state, action.word];
+    default:
+      return state;
+  }
+}
+
+export default chosenWords;

--- a/src/redux/reducers/chosenWords/chosenWords.ts
+++ b/src/redux/reducers/chosenWords/chosenWords.ts
@@ -4,8 +4,10 @@ type state = string[ ] | [ ];
 
 const chosenWords = (state: state = [ ], action: ActionObject) => {
   switch(action.type) {
-    case 'ADD_SELECTED_WORD':
-      return [...state, action.word];
+    case 'ADD_WORD':
+      return [...state, action.chosenWord];
+    case 'REMOVE_WORD':
+      return state.filter(word => word !== action.chosenWord);
     default:
       return state;
   }

--- a/src/redux/reducers/currentBrainstorm/currentBrainstorm.test.ts
+++ b/src/redux/reducers/currentBrainstorm/currentBrainstorm.test.ts
@@ -1,12 +1,16 @@
 import currentBrainstormReducer from './currentBrainstorm';
-import { ActionObject, Brainstorm } from 'interfaces';
+import { ActionObject, Brainstorm, IAddCurrentBrainstormAction, IRemoveCurrentBrainstormAction } from 'interfaces';
 
 type emptyObject = { };
 
 describe('currentBrainstormReducer', () => {
   it("should return initial value", () => {
+    const mockAction: ActionObject = {
+      type: '',
+      currentBrainstorm: undefined
+    };
     const expected: emptyObject = { };
-    const result = currentBrainstormReducer(undefined, {type: '', currentBrainstorm: undefined });
+    const result = currentBrainstormReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
   });
@@ -17,10 +21,10 @@ describe('currentBrainstormReducer', () => {
       idea: 'Idea',
       action: 'Do sth',
       isGenius: true,
-      categories: [1, 2]
+      categories: [{id: 1, name: 'Tech'}]
     };
 
-    const mockAction: ActionObject = {
+    const mockAction: IAddCurrentBrainstormAction = {
       type: 'ADD_CURRENT_BRAINSTORM',
       currentBrainstorm: mockBrainstorm
     };
@@ -30,5 +34,17 @@ describe('currentBrainstormReducer', () => {
     const result: Brainstorm = currentBrainstormReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
-  })
+  });
+
+  it("should return the empty array if type of action is REMOVE_CURRENT_BRAINSTORM", () => {
+    const mockAction: IRemoveCurrentBrainstormAction = {
+      type: 'REMOVE_CURRENT_BRAINSTORM'
+    };
+
+    const expected: emptyObject = { };
+
+    const result: Brainstorm = currentBrainstormReducer(undefined, mockAction);
+
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/redux/reducers/currentBrainstorm/currentBrainstorm.test.ts
+++ b/src/redux/reducers/currentBrainstorm/currentBrainstorm.test.ts
@@ -1,0 +1,34 @@
+import currentBrainstormReducer from './currentBrainstorm';
+import { ActionObject, Brainstorm } from 'interfaces';
+
+type emptyObject = { };
+
+describe('currentBrainstormReducer', () => {
+  it("should return initial value", () => {
+    const expected: emptyObject = { };
+    const result = currentBrainstormReducer(undefined, {type: '', currentBrainstorm: undefined });
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return the current brainstorm if type of action is ADD_CURRENT_BRAINSTORM", () => {
+    const mockBrainstorm: Brainstorm = {
+      question: 'What?',
+      idea: 'Idea',
+      action: 'Do sth',
+      isGenius: true,
+      categories: [1, 2]
+    };
+
+    const mockAction: ActionObject = {
+      type: 'ADD_CURRENT_BRAINSTORM',
+      currentBrainstorm: mockBrainstorm
+    };
+
+    const expected: Brainstorm = mockBrainstorm;
+
+    const result: Brainstorm = currentBrainstormReducer(undefined, mockAction);
+
+    expect(result).toEqual(expected);
+  })
+});

--- a/src/redux/reducers/currentBrainstorm/currentBrainstorm.ts
+++ b/src/redux/reducers/currentBrainstorm/currentBrainstorm.ts
@@ -6,6 +6,8 @@ const currentBrainstorm = (state: state = { }, action: ActionObject) => {
   switch(action.type) {
     case 'ADD_CURRENT_BRAINSTORM':
       return action.currentBrainstorm;
+    case 'REMOVE_CURRENT_BRAINSTORM':
+      return {};
     default:
       return state;
   }

--- a/src/redux/reducers/currentBrainstorm/currentBrainstorm.ts
+++ b/src/redux/reducers/currentBrainstorm/currentBrainstorm.ts
@@ -1,0 +1,14 @@
+import { ActionObject, Brainstorm } from 'interfaces';
+
+type state = Brainstorm | { };
+
+const currentBrainstorm = (state: state = { }, action: ActionObject) => {
+  switch(action.type) {
+    case 'ADD_CURRENT_BRAINSTORM':
+      return action.currentBrainstorm;
+    default:
+      return state;
+  }
+}
+
+export default currentBrainstorm;

--- a/src/redux/reducers/filter/filter.test.ts
+++ b/src/redux/reducers/filter/filter.test.ts
@@ -1,0 +1,26 @@
+import filterReducer from './filter';
+import { ActionObject } from 'interfaces';
+
+describe('filterReducer', () => {
+  it("should return initial value", () => {
+    const expected: string = '';
+    const result = filterReducer(undefined, {type: '', filter: undefined });
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return a filter string if type of action is ADD_FILTER", () => {
+    const mockFilter: string = 'Tech';
+
+    const mockAction: ActionObject = {
+      type: 'ADD_FILTER',
+      filter: mockFilter
+    };
+
+    const expected: string = mockFilter;
+
+    const result: string = filterReducer(undefined, mockAction);
+
+    expect(result).toEqual(expected);
+  })
+});

--- a/src/redux/reducers/filter/filter.test.ts
+++ b/src/redux/reducers/filter/filter.test.ts
@@ -1,10 +1,14 @@
 import filterReducer from './filter';
-import { ActionObject } from 'interfaces';
+import { ActionObject, IAddFilterAction, IRemoveFilterAction } from 'interfaces';
 
 describe('filterReducer', () => {
   it("should return initial value", () => {
+    const mockAction: ActionObject = {
+      type: '',
+      filter: undefined
+    };
     const expected: string = '';
-    const result = filterReducer(undefined, {type: '', filter: undefined });
+    const result = filterReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
   });
@@ -12,7 +16,7 @@ describe('filterReducer', () => {
   it("should return a filter string if type of action is ADD_FILTER", () => {
     const mockFilter: string = 'Tech';
 
-    const mockAction: ActionObject = {
+    const mockAction: IAddFilterAction = {
       type: 'ADD_FILTER',
       filter: mockFilter
     };
@@ -22,5 +26,17 @@ describe('filterReducer', () => {
     const result: string = filterReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
-  })
+  });
+
+  it("should return an empty string if type of action is REMOVE_FILTER", () => {
+    const mockAction: IRemoveFilterAction = {
+      type: 'REMOVE_FILTER'
+    };
+
+    const expected: string = '';
+
+    const result: string = filterReducer('Tech', mockAction);
+
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/redux/reducers/filter/filter.ts
+++ b/src/redux/reducers/filter/filter.ts
@@ -6,6 +6,8 @@ const filter = (state: state = '', action: ActionObject) => {
   switch(action.type) {
     case 'ADD_FILTER':
       return action.filter;
+    case 'REMOVE_FILTER':
+      return '';
     default:
       return state;
   }

--- a/src/redux/reducers/filter/filter.ts
+++ b/src/redux/reducers/filter/filter.ts
@@ -1,0 +1,14 @@
+import { ActionObject } from 'interfaces';
+
+type state = string | '';
+
+const filter = (state: state = '', action: ActionObject) => {
+  switch(action.type) {
+    case 'ADD_FILTER':
+      return action.filter;
+    default:
+      return state;
+  }
+}
+
+export default filter;

--- a/src/redux/reducers/index.ts
+++ b/src/redux/reducers/index.ts
@@ -1,8 +1,34 @@
 import { combineReducers } from 'redux';
-import userReducer from '../reducers/userReducer';
+import user from '../reducers/user/user';
+import allBrainstorms from '../reducers/allBrainstorms/allBrainstorms';
+import categories from '../reducers/categories/categories';
+import actions from '../reducers/actions/actions';
+import randomWordCollections from '../reducers/randomWordCollections/randomWordCollections';
+import questionTemplates from '../reducers/questionTemplates/questionTemplates';
+import secretSauce from '../reducers/secretSauce/secretSauce';
+import currentBrainstorm from '../reducers/currentBrainstorm/currentBrainstorm';
+import chosenWords from '../reducers/chosenWords/chosenWords';
+import insights from '../reducers/insights/insights';
+import query from '../reducers/query/query';
+import filter from '../reducers/filter/filter';
+import timeEnded from '../reducers/timeEnded/timeEnded';
+import instructionsEnded from '../reducers/instructionsEnded/instructionsEnded';
 
 const rootReducer = combineReducers({
-  user: userReducer
+  user,
+  allBrainstorms,
+  categories,
+  actions,
+  randomWordCollections,
+  questionTemplates,
+  secretSauce,
+  currentBrainstorm,
+  chosenWords,
+  insights,
+  query,
+  filter,
+  timeEnded,
+  instructionsEnded
 });
 
 export default rootReducer;

--- a/src/redux/reducers/insights/insights.test.ts
+++ b/src/redux/reducers/insights/insights.test.ts
@@ -1,12 +1,16 @@
 import insightsReducer from './insights';
-import { ActionObject, Insight } from 'interfaces';
+import { ActionObject, Insight, IAddInsightAction } from 'interfaces';
 
 type emptyArray = [];
 
 describe('insightsReducer', () => {
   it("should return initial value", () => {
+    const mockAction: ActionObject = {
+      type: '',
+      insight: undefined
+    };
     const expected: emptyArray = [];
-    const result = insightsReducer(undefined, {type: '', insight: undefined });
+    const result = insightsReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
   });
@@ -18,7 +22,7 @@ describe('insightsReducer', () => {
       answers: ['Fighting']
     };
 
-    const mockAction: ActionObject = {
+    const mockAction: IAddInsightAction = {
       type: 'ADD_INSIGHT',
       insight: mockInsight
     };

--- a/src/redux/reducers/insights/insights.test.ts
+++ b/src/redux/reducers/insights/insights.test.ts
@@ -1,0 +1,32 @@
+import insightsReducer from './insights';
+import { ActionObject, Insight } from 'interfaces';
+
+type emptyArray = [];
+
+describe('insightsReducer', () => {
+  it("should return initial value", () => {
+    const expected: emptyArray = [];
+    const result = insightsReducer(undefined, {type: '', insight: undefined });
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return the array with a new insight if type of action is ADD_INSIGHT", () => {
+    const mockInsight: Insight = {
+      id: 1,
+      question: 'What?',
+      answers: ['Fighting']
+    };
+
+    const mockAction: ActionObject = {
+      type: 'ADD_INSIGHT',
+      insight: mockInsight
+    };
+
+    const expected: Insight[] = [ mockInsight ];
+
+    const result: Insight[] = insightsReducer(undefined, mockAction);
+
+    expect(result).toEqual(expected);
+  })
+});

--- a/src/redux/reducers/insights/insights.ts
+++ b/src/redux/reducers/insights/insights.ts
@@ -1,0 +1,14 @@
+import { ActionObject, Insight } from 'interfaces';
+
+type state = Insight[] | [];
+
+const insights = (state: state = [], action: ActionObject) => {
+  switch(action.type) {
+    case 'ADD_INSIGHT':
+      return [...state, action.insight];
+    default:
+      return state;
+  }
+}
+
+export default insights;

--- a/src/redux/reducers/instructionsEnded/instructionsEnded.test.ts
+++ b/src/redux/reducers/instructionsEnded/instructionsEnded.test.ts
@@ -1,0 +1,24 @@
+import instructionsEndedReducer from './instructionsEnded';
+import { ActionObject } from 'interfaces';
+
+describe('instructionsEndedReducer', () => {
+  it("should return initial value", () => {
+    const expected: boolean = false;
+    const result = instructionsEndedReducer(undefined, {type: '', isEnded: undefined });
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return the result of instructions end if type of action is CHANGE_IS_ENDED", () => {
+    const mockAction: ActionObject = {
+      type: 'CHANGE_IS_ENDED',
+      isEnded: true
+    };
+
+    const expected: boolean = true;
+
+    const result: boolean = instructionsEndedReducer(undefined, mockAction);
+
+    expect(result).toEqual(expected);
+  })
+});

--- a/src/redux/reducers/instructionsEnded/instructionsEnded.test.ts
+++ b/src/redux/reducers/instructionsEnded/instructionsEnded.test.ts
@@ -3,22 +3,37 @@ import { ActionObject } from 'interfaces';
 
 describe('instructionsEndedReducer', () => {
   it("should return initial value", () => {
+    const mockAction: ActionObject = {
+      type: '',
+      isEnded: undefined
+    };
     const expected: boolean = false;
-    const result = instructionsEndedReducer(undefined, {type: '', isEnded: undefined });
+    const result = instructionsEndedReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
   });
 
-  it("should return the result of instructions end if type of action is CHANGE_IS_ENDED", () => {
+  it("should return true if type of action is END_INSTRUCTIONS", () => {
     const mockAction: ActionObject = {
-      type: 'CHANGE_IS_ENDED',
-      isEnded: true
+      type: 'END_INSTRUCTIONS'
     };
 
     const expected: boolean = true;
 
-    const result: boolean = instructionsEndedReducer(undefined, mockAction);
+    const result = instructionsEndedReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
-  })
+  });
+
+  it("should return false if type of action is REVERSE_INSTRUCTIONS", () => {
+    const mockAction: ActionObject = {
+      type: 'REVERSE_INSTRUCTIONS'
+    };
+
+    const expected: boolean = false;
+
+    const result = instructionsEndedReducer(true, mockAction);
+
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/redux/reducers/instructionsEnded/instructionsEnded.ts
+++ b/src/redux/reducers/instructionsEnded/instructionsEnded.ts
@@ -1,0 +1,12 @@
+import { ActionObject } from 'interfaces';
+
+const instructionsEnded = (state: boolean = false, action: ActionObject) => {
+  switch(action.type) {
+    case 'CHANGE_IS_ENDED':
+      return action.isEnded;
+    default:
+      return state;
+  }
+}
+
+export default instructionsEnded;

--- a/src/redux/reducers/instructionsEnded/instructionsEnded.ts
+++ b/src/redux/reducers/instructionsEnded/instructionsEnded.ts
@@ -2,8 +2,10 @@ import { ActionObject } from 'interfaces';
 
 const instructionsEnded = (state: boolean = false, action: ActionObject) => {
   switch(action.type) {
-    case 'CHANGE_IS_ENDED':
-      return action.isEnded;
+    case 'END_INSTRUCTIONS':
+      return true;
+    case 'REVERSE_INSTRUCTIONS':
+      return false;
     default:
       return state;
   }

--- a/src/redux/reducers/query/query.test.ts
+++ b/src/redux/reducers/query/query.test.ts
@@ -1,0 +1,26 @@
+import queryReducer from './query';
+import { ActionObject } from 'interfaces';
+
+describe('queryReducer', () => {
+  it("should return initial value", () => {
+    const expected: string = '';
+    const result = queryReducer(undefined, {type: '', query: undefined });
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return a query string if type of action is ADD_QUERY", () => {
+    const mockFilter: string = 'Tech';
+
+    const mockAction: ActionObject = {
+      type: 'ADD_QUERY',
+      query: mockFilter
+    };
+
+    const expected: string = mockFilter;
+
+    const result: string = queryReducer(undefined, mockAction);
+
+    expect(result).toEqual(expected);
+  })
+});

--- a/src/redux/reducers/query/query.test.ts
+++ b/src/redux/reducers/query/query.test.ts
@@ -1,26 +1,42 @@
 import queryReducer from './query';
-import { ActionObject } from 'interfaces';
+import { ActionObject, IAddQueryAction, IRemoveQueryAction } from 'interfaces';
 
 describe('queryReducer', () => {
   it("should return initial value", () => {
+    const mockAction: ActionObject = {
+      type: '',
+      query: undefined
+    };
     const expected: string = '';
-    const result = queryReducer(undefined, {type: '', query: undefined });
+    const result = queryReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
   });
 
   it("should return a query string if type of action is ADD_QUERY", () => {
-    const mockFilter: string = 'Tech';
+    const mockQuery: string = 'App';
 
-    const mockAction: ActionObject = {
+    const mockAction: IAddQueryAction = {
       type: 'ADD_QUERY',
-      query: mockFilter
+      query: mockQuery
     };
 
-    const expected: string = mockFilter;
+    const expected: string = mockQuery;
 
     const result: string = queryReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
-  })
+  });
+
+  it("should return an empty string if type of action is REMOVE_QUERY", () => {
+    const mockAction: IRemoveQueryAction = {
+      type: 'REMOVE_QUERY'
+    };
+
+    const expected: string = '';
+
+    const result: string = queryReducer('app', mockAction);
+
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/redux/reducers/query/query.ts
+++ b/src/redux/reducers/query/query.ts
@@ -6,6 +6,8 @@ const query = (state: state = '', action: ActionObject) => {
   switch(action.type) {
     case 'ADD_QUERY':
       return action.query;
+    case 'REMOVE_QUERY':
+      return '';
     default:
       return state;
   }

--- a/src/redux/reducers/query/query.ts
+++ b/src/redux/reducers/query/query.ts
@@ -1,0 +1,14 @@
+import { ActionObject } from 'interfaces';
+
+type state = string | '';
+
+const query = (state: state = '', action: ActionObject) => {
+  switch(action.type) {
+    case 'ADD_QUERY':
+      return action.query;
+    default:
+      return state;
+  }
+}
+
+export default query;

--- a/src/redux/reducers/questionTemplates/questionTemplates.test.ts
+++ b/src/redux/reducers/questionTemplates/questionTemplates.test.ts
@@ -1,23 +1,27 @@
 import questionTemplatesReducer from './questionTemplates';
-import { ActionObject } from 'interfaces';
+import { ActionObject, IAddQuestionTemplatesAction } from 'interfaces';
 
 type emptyArray = [ ];
 
 describe('questionTemplatesReducer', () => {
   it("should return initial value", () => {
+    const mockAction: ActionObject = {
+      type: '',
+      templates: undefined
+    };
     const expected: emptyArray = [ ];
-    const result = questionTemplatesReducer(undefined, {type: '', templates: undefined });
+    const result = questionTemplatesReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
   });
 
-  it("should return the array with question templates if type of action is ADD_TEMPLATES", () => {
+  it("should return the array with question templates if type of action is ADD_ALL_TEMPLATES", () => {
     const mockTemplates: string[] = [
       'What do you eat?'
     ];
 
-    const mockAction: ActionObject = {
-      type: 'ADD_TEMPLATES',
+    const mockAction: IAddQuestionTemplatesAction = {
+      type: 'ADD_ALL_TEMPLATES',
       templates: mockTemplates
     };
 

--- a/src/redux/reducers/questionTemplates/questionTemplates.test.ts
+++ b/src/redux/reducers/questionTemplates/questionTemplates.test.ts
@@ -1,0 +1,30 @@
+import questionTemplatesReducer from './questionTemplates';
+import { ActionObject } from 'interfaces';
+
+type emptyArray = [ ];
+
+describe('questionTemplatesReducer', () => {
+  it("should return initial value", () => {
+    const expected: emptyArray = [ ];
+    const result = questionTemplatesReducer(undefined, {type: '', templates: undefined });
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return the array with question templates if type of action is ADD_TEMPLATES", () => {
+    const mockTemplates: string[] = [
+      'What do you eat?'
+    ];
+
+    const mockAction: ActionObject = {
+      type: 'ADD_TEMPLATES',
+      templates: mockTemplates
+    };
+
+    const expected: string[] = mockTemplates;
+
+    const result: string[] = questionTemplatesReducer(undefined, mockAction);
+
+    expect(result).toEqual(expected);
+  })
+});

--- a/src/redux/reducers/questionTemplates/questionTemplates.ts
+++ b/src/redux/reducers/questionTemplates/questionTemplates.ts
@@ -1,0 +1,14 @@
+import { ActionObject } from 'interfaces';
+
+type state = string[] | [];
+
+const questionTemplates = (state: state = [], action: ActionObject) => {
+  switch(action.type) {
+    case 'ADD_TEMPLATES':
+      return action.templates;
+    default:
+      return state;
+  }
+}
+
+export default questionTemplates;

--- a/src/redux/reducers/questionTemplates/questionTemplates.ts
+++ b/src/redux/reducers/questionTemplates/questionTemplates.ts
@@ -4,7 +4,7 @@ type state = string[] | [];
 
 const questionTemplates = (state: state = [], action: ActionObject) => {
   switch(action.type) {
-    case 'ADD_TEMPLATES':
+    case 'ADD_ALL_TEMPLATES':
       return action.templates;
     default:
       return state;

--- a/src/redux/reducers/randomWordCollections/randomWordCollection.test.ts
+++ b/src/redux/reducers/randomWordCollections/randomWordCollection.test.ts
@@ -1,32 +1,36 @@
 import randomWordCollectionsReducer from './randomWordCollections';
-import { ActionObject, randomWordCollection } from 'interfaces';
+import { ActionObject, RandomWordCollection, IAddRandomWordCollectionsAction } from 'interfaces';
 
 type emptyArray = [ ];
 
 describe('randomWordCollectionsReducer', () => {
   it("should return initial value", () => {
+    const mockAction: ActionObject = {
+      type: '',
+      collections: undefined
+    };
     const expected: emptyArray = [ ];
-    const result = randomWordCollectionsReducer(undefined, {type: '', collections: undefined });
+    const result = randomWordCollectionsReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
   });
 
-  it("should return the array of random collections if type of action is ADD_RANDOM_COLLECTIONS", () => {
-    const mockCollections: randomWordCollection[] = [{
+  it("should return the array of random collections if type of action is ADD_ALL_COLLECTIONS", () => {
+    const mockCollections: RandomWordCollection[] = [{
       'question': {
         type: 'noun',
         connectedWord: ['answer']
       }
     }];
 
-    const mockAction: ActionObject = {
-      type: 'ADD_RANDOM_COLLECTIONS',
+    const mockAction: IAddRandomWordCollectionsAction = {
+      type: 'ADD_ALL_COLLECTIONS',
       collections: mockCollections
     };
 
-    const expected: randomWordCollection[] = mockCollections;
+    const expected: RandomWordCollection[] = mockCollections;
 
-    const result: randomWordCollection[] = randomWordCollectionsReducer(undefined, mockAction);
+    const result: RandomWordCollection[] = randomWordCollectionsReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
   })

--- a/src/redux/reducers/randomWordCollections/randomWordCollection.test.ts
+++ b/src/redux/reducers/randomWordCollections/randomWordCollection.test.ts
@@ -1,0 +1,33 @@
+import randomWordCollectionsReducer from './randomWordCollections';
+import { ActionObject, randomWordCollection } from 'interfaces';
+
+type emptyArray = [ ];
+
+describe('randomWordCollectionsReducer', () => {
+  it("should return initial value", () => {
+    const expected: emptyArray = [ ];
+    const result = randomWordCollectionsReducer(undefined, {type: '', collections: undefined });
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return the array of random collections if type of action is ADD_RANDOM_COLLECTIONS", () => {
+    const mockCollections: randomWordCollection[] = [{
+      'question': {
+        type: 'noun',
+        connectedWord: ['answer']
+      }
+    }];
+
+    const mockAction: ActionObject = {
+      type: 'ADD_RANDOM_COLLECTIONS',
+      collections: mockCollections
+    };
+
+    const expected: randomWordCollection[] = mockCollections;
+
+    const result: randomWordCollection[] = randomWordCollectionsReducer(undefined, mockAction);
+
+    expect(result).toEqual(expected);
+  })
+});

--- a/src/redux/reducers/randomWordCollections/randomWordCollections.ts
+++ b/src/redux/reducers/randomWordCollections/randomWordCollections.ts
@@ -1,10 +1,10 @@
-import { ActionObject, randomWordCollection } from 'interfaces';
+import { ActionObject, RandomWordCollection } from 'interfaces';
 
-type state = randomWordCollection[] | [ ];
+type state = RandomWordCollection[] | [ ];
 
 const randomWordCollections = (state: state = [ ], action: ActionObject) => {
   switch(action.type) {
-    case 'ADD_RANDOM_COLLECTIONS':
+    case 'ADD_ALL_COLLECTIONS':
       return action.collections;
     default:
       return state;

--- a/src/redux/reducers/randomWordCollections/randomWordCollections.ts
+++ b/src/redux/reducers/randomWordCollections/randomWordCollections.ts
@@ -1,0 +1,14 @@
+import { ActionObject, randomWordCollection } from 'interfaces';
+
+type state = randomWordCollection[] | [ ];
+
+const randomWordCollections = (state: state = [ ], action: ActionObject) => {
+  switch(action.type) {
+    case 'ADD_RANDOM_COLLECTIONS':
+      return action.collections;
+    default:
+      return state;
+  }
+}
+
+export default randomWordCollections;

--- a/src/redux/reducers/secretSauce/secretSauce.test.ts
+++ b/src/redux/reducers/secretSauce/secretSauce.test.ts
@@ -1,0 +1,30 @@
+import secretSauceReducer from './secretSauce';
+import { ActionObject } from 'interfaces';
+
+type emptyArray = [];
+
+describe('secretSauceReducer', () => {
+  it("should return initial value", () => {
+    const expected: emptyArray = [];
+    const result = secretSauceReducer(undefined, {type: '', words: undefined });
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return the array of random words if type of action is ADD_SECRET_SAUCE", () => {
+    const mockWords: string[] = [
+      'rose', 'clue'
+    ];
+
+    const mockAction: ActionObject = {
+      type: 'ADD_SECRET_SAUCE',
+      words: mockWords
+    };
+
+    const expected: string[] = mockWords;
+
+    const result: string[] = secretSauceReducer(undefined, mockAction);
+
+    expect(result).toEqual(expected);
+  })
+});

--- a/src/redux/reducers/secretSauce/secretSauce.test.ts
+++ b/src/redux/reducers/secretSauce/secretSauce.test.ts
@@ -5,8 +5,12 @@ type emptyArray = [];
 
 describe('secretSauceReducer', () => {
   it("should return initial value", () => {
+    const mockAction: ActionObject = {
+      type: '',
+      secretSauce: undefined
+    };
     const expected: emptyArray = [];
-    const result = secretSauceReducer(undefined, {type: '', words: undefined });
+    const result = secretSauceReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
   });
@@ -18,7 +22,7 @@ describe('secretSauceReducer', () => {
 
     const mockAction: ActionObject = {
       type: 'ADD_SECRET_SAUCE',
-      words: mockWords
+      secretSauce: mockWords
     };
 
     const expected: string[] = mockWords;

--- a/src/redux/reducers/secretSauce/secretSauce.ts
+++ b/src/redux/reducers/secretSauce/secretSauce.ts
@@ -5,7 +5,7 @@ type state = string[] | [ ];
 const secretSauce = (state: state = [ ], action: ActionObject) => {
   switch(action.type) {
     case 'ADD_SECRET_SAUCE':
-      return action.words;
+      return action.secretSauce;
     default:
       return state;
   }

--- a/src/redux/reducers/secretSauce/secretSauce.ts
+++ b/src/redux/reducers/secretSauce/secretSauce.ts
@@ -1,0 +1,14 @@
+import { ActionObject } from 'interfaces';
+
+type state = string[] | [ ];
+
+const secretSauce = (state: state = [ ], action: ActionObject) => {
+  switch(action.type) {
+    case 'ADD_SECRET_SAUCE':
+      return action.words;
+    default:
+      return state;
+  }
+}
+
+export default secretSauce;

--- a/src/redux/reducers/timeEnded/timeEnded.test.ts
+++ b/src/redux/reducers/timeEnded/timeEnded.test.ts
@@ -1,24 +1,39 @@
 import timeEndedReducer from './timeEnded';
-import { ActionObject } from 'interfaces';
+import { ActionObject, IEndTimeAction, IReverseTimeAction } from 'interfaces';
 
 describe('instructionsEndedReducer', () => {
   it("should return initial value", () => {
+    const mockAction: ActionObject = {
+      type: '',
+      isEnded: undefined
+    };
     const expected: boolean = false;
-    const result = timeEndedReducer(undefined, {type: '', isEnded: undefined });
+    const result = timeEndedReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
   });
 
-  it("should return the result of instructions end if type of action is CHANGE_IS_ENDED", () => {
-    const mockAction: ActionObject = {
-      type: 'CHANGE_IS_ENDED',
-      isEnded: true
+  it("should return true if type of action is END_TIME", () => {
+    const mockAction: IEndTimeAction = {
+      type: 'END_TIME'
     };
 
     const expected: boolean = true;
 
-    const result: boolean = timeEndedReducer(undefined, mockAction);
+    const result = timeEndedReducer(undefined, mockAction);
 
     expect(result).toEqual(expected);
-  })
+  });
+
+  it("should return false if type of action is REVERSE_TIME", () => {
+    const mockAction: IReverseTimeAction = {
+      type: 'REVERSE_TIME'
+    };
+
+    const expected: boolean = false;
+
+    const result = timeEndedReducer(true, mockAction);
+
+    expect(result).toEqual(expected);
+  });
 });

--- a/src/redux/reducers/timeEnded/timeEnded.test.ts
+++ b/src/redux/reducers/timeEnded/timeEnded.test.ts
@@ -1,0 +1,24 @@
+import timeEndedReducer from './timeEnded';
+import { ActionObject } from 'interfaces';
+
+describe('instructionsEndedReducer', () => {
+  it("should return initial value", () => {
+    const expected: boolean = false;
+    const result = timeEndedReducer(undefined, {type: '', isEnded: undefined });
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return the result of instructions end if type of action is CHANGE_IS_ENDED", () => {
+    const mockAction: ActionObject = {
+      type: 'CHANGE_IS_ENDED',
+      isEnded: true
+    };
+
+    const expected: boolean = true;
+
+    const result: boolean = timeEndedReducer(undefined, mockAction);
+
+    expect(result).toEqual(expected);
+  })
+});

--- a/src/redux/reducers/timeEnded/timeEnded.ts
+++ b/src/redux/reducers/timeEnded/timeEnded.ts
@@ -1,0 +1,12 @@
+import { ActionObject } from 'interfaces';
+
+const timeEnded = (state: boolean = false, action: ActionObject) => {
+  switch(action.type) {
+    case 'CHANGE_IS_ENDED':
+      return action.isEnded;
+    default:
+      return state;
+  }
+}
+
+export default timeEnded;

--- a/src/redux/reducers/timeEnded/timeEnded.ts
+++ b/src/redux/reducers/timeEnded/timeEnded.ts
@@ -2,8 +2,10 @@ import { ActionObject } from 'interfaces';
 
 const timeEnded = (state: boolean = false, action: ActionObject) => {
   switch(action.type) {
-    case 'CHANGE_IS_ENDED':
-      return action.isEnded;
+    case 'END_TIME':
+      return true;
+    case 'REVERSE_TIME':
+      return false;
     default:
       return state;
   }

--- a/src/redux/reducers/user/user.test.ts
+++ b/src/redux/reducers/user/user.test.ts
@@ -1,9 +1,10 @@
-import userReducer from './userReducer';
-import { ActionObject } from '../../interfaces';
-import { UserLoginReceived } from '../../interfaces';
+import userReducer from './user';
+import { ActionObject } from 'interfaces';
+import { UserLoginReceived } from 'interfaces';
 
 describe('userReducer', () => {
   let action: ActionObject;
+
   beforeEach(() => {
     action = {type: '', payload: {}}
   });

--- a/src/redux/reducers/user/user.ts
+++ b/src/redux/reducers/user/user.ts
@@ -1,4 +1,4 @@
-import { ActionObject } from '../../interfaces';
+import { ActionObject } from 'interfaces';
 
 const userReducer = (state:object = {}, action:ActionObject) => {
   switch(action.type) {
@@ -10,7 +10,7 @@ const userReducer = (state:object = {}, action:ActionObject) => {
       }
     case 'LOG_OUT_USER':
       return {}
-    default: 
+    default:
       return state
   }
 }


### PR DESCRIPTION
### This PR contains the next changes:

- Updated interfaces: fixing errors, adding readonly type for not changeable data, adding actions property to AppStore interface.
- Updated connection with Redux: adding correct check type with AppStore interface.
- Added all reducers to root reducer based on AppStore interface.
- Added structure for every reducer
- Added test for reducers

### Tests

- `git fetch`
- `git checkout reducers`
- `npm test`
- 29 tests for reducers should be passed.

Resolves #26 