### PR TITLE
Bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8497,9 +8497,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
         }
       }
     },

--- a/src/Components/BrainstormCategory/BrainstormCategory.test.tsx
+++ b/src/Components/BrainstormCategory/BrainstormCategory.test.tsx
@@ -4,15 +4,16 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import BrainstormCategory from './BrainstormCategory';
+import { IBrainstormForm } from 'interfaces';
 
 describe('BrainstormCategory', () => {
   let wrapper: any;
 
-  const mockFormState = {
+  const mockFormState: IBrainstormForm = {
     question: '',
     categories: [],
-    action: 'create an app',
-    reset: true
+    action: {id: 1, action: 'create an app'},
+    reset: false
   };
 
   const mockCategory = {
@@ -67,5 +68,19 @@ describe('BrainstormCategory', () => {
     wrapper.find('button').simulate('click');
 
     expect(mockSetCategory).toHaveBeenCalledWith(mockArgument);
+  });
+
+  it('should reset local state when formState.reset is true', () => {
+    wrapper.find('button').simulate('click');
+    expect(wrapper).toMatchSnapshot();
+
+    wrapper.setProps({
+      category: mockCategory,
+      formState: {...mockFormState, reset: true},
+      mockSetCategory: jest.fn()
+    });
+
+    wrapper.update();
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/Components/BrainstormCategory/BrainstormCategory.tsx
+++ b/src/Components/BrainstormCategory/BrainstormCategory.tsx
@@ -31,6 +31,10 @@ const BrainstormCategory:React.FC<Props> = (props) => {
 
   useEffect(addRemoveCategory, [ active ]);
 
+  useEffect(() => {
+    if (formState.reset) return setActive(false);
+  }, [formState]);
+
   const btnClassName: string = active ? 'category-btn active' : 'category-btn';
 
   return (

--- a/src/Components/BrainstormCategory/__snapshots__/BrainstormCategory.test.tsx.snap
+++ b/src/Components/BrainstormCategory/__snapshots__/BrainstormCategory.test.tsx.snap
@@ -10,10 +10,13 @@ exports[`BrainstormCategory should match the snapshot 1`] = `
   }
   formState={
     Object {
-      "action": "create an app",
+      "action": Object {
+        "action": "create an app",
+        "id": 1,
+      },
       "categories": Array [],
       "question": "",
-      "reset": true,
+      "reset": false,
     }
   }
   setCategory={
@@ -21,10 +24,13 @@ exports[`BrainstormCategory should match the snapshot 1`] = `
       "calls": Array [
         Array [
           Object {
-            "action": "create an app",
+            "action": Object {
+              "action": "create an app",
+              "id": 1,
+            },
             "categories": Array [],
             "question": "",
-            "reset": true,
+            "reset": false,
           },
         ],
       ],
@@ -58,10 +64,13 @@ exports[`BrainstormCategory should render a different snapshot after a click eve
   }
   formState={
     Object {
-      "action": "create an app",
+      "action": Object {
+        "action": "create an app",
+        "id": 1,
+      },
       "categories": Array [],
       "question": "",
-      "reset": true,
+      "reset": false,
     }
   }
   setCategory={
@@ -69,15 +78,21 @@ exports[`BrainstormCategory should render a different snapshot after a click eve
       "calls": Array [
         Array [
           Object {
-            "action": "create an app",
+            "action": Object {
+              "action": "create an app",
+              "id": 1,
+            },
             "categories": Array [],
             "question": "",
-            "reset": true,
+            "reset": false,
           },
         ],
         Array [
           Object {
-            "action": "create an app",
+            "action": Object {
+              "action": "create an app",
+              "id": 1,
+            },
             "categories": Array [
               Object {
                 "id": 1,
@@ -85,7 +100,7 @@ exports[`BrainstormCategory should render a different snapshot after a click eve
               },
             ],
             "question": "",
-            "reset": true,
+            "reset": false,
           },
         ],
       ],
@@ -104,6 +119,170 @@ exports[`BrainstormCategory should render a different snapshot after a click eve
 >
   <button
     className="category-btn active"
+    onClick={[Function]}
+    type="button"
+    value="Technology"
+  >
+    Technology
+  </button>
+</BrainstormCategory>
+`;
+
+exports[`BrainstormCategory should reset local state when formState.reset is true 1`] = `
+<BrainstormCategory
+  category={
+    Object {
+      "id": 1,
+      "name": "Technology",
+    }
+  }
+  formState={
+    Object {
+      "action": Object {
+        "action": "create an app",
+        "id": 1,
+      },
+      "categories": Array [],
+      "question": "",
+      "reset": false,
+    }
+  }
+  setCategory={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          Object {
+            "action": Object {
+              "action": "create an app",
+              "id": 1,
+            },
+            "categories": Array [],
+            "question": "",
+            "reset": false,
+          },
+        ],
+        Array [
+          Object {
+            "action": Object {
+              "action": "create an app",
+              "id": 1,
+            },
+            "categories": Array [
+              Object {
+                "id": 1,
+                "name": "Technology",
+              },
+            ],
+            "question": "",
+            "reset": false,
+          },
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
+>
+  <button
+    className="category-btn active"
+    onClick={[Function]}
+    type="button"
+    value="Technology"
+  >
+    Technology
+  </button>
+</BrainstormCategory>
+`;
+
+exports[`BrainstormCategory should reset local state when formState.reset is true 2`] = `
+<BrainstormCategory
+  category={
+    Object {
+      "id": 1,
+      "name": "Technology",
+    }
+  }
+  formState={
+    Object {
+      "action": Object {
+        "action": "create an app",
+        "id": 1,
+      },
+      "categories": Array [],
+      "question": "",
+      "reset": true,
+    }
+  }
+  mockSetCategory={[MockFunction]}
+  setCategory={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          Object {
+            "action": Object {
+              "action": "create an app",
+              "id": 1,
+            },
+            "categories": Array [],
+            "question": "",
+            "reset": false,
+          },
+        ],
+        Array [
+          Object {
+            "action": Object {
+              "action": "create an app",
+              "id": 1,
+            },
+            "categories": Array [
+              Object {
+                "id": 1,
+                "name": "Technology",
+              },
+            ],
+            "question": "",
+            "reset": false,
+          },
+        ],
+        Array [
+          Object {
+            "action": Object {
+              "action": "create an app",
+              "id": 1,
+            },
+            "categories": Array [],
+            "question": "",
+            "reset": true,
+          },
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
+>
+  <button
+    className="category-btn"
     onClick={[Function]}
     type="button"
     value="Technology"

--- a/src/Components/GenerateInsights/GenerateInsights.scss
+++ b/src/Components/GenerateInsights/GenerateInsights.scss
@@ -2,7 +2,8 @@
 @import '../../css/index.scss';
 
 .insights-div {
-  width: 90%;
+  max-width: 34vw;
+  height: fit-content;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/Components/GenerateInsights/GenerateInsights.scss
+++ b/src/Components/GenerateInsights/GenerateInsights.scss
@@ -19,6 +19,7 @@
   }
   h3 {
     font-size: 1rem;
+    text-align: left;
   }
   box-shadow: $external-shadow;
 }

--- a/src/Components/Header/Header.test.tsx
+++ b/src/Components/Header/Header.test.tsx
@@ -2,6 +2,12 @@ import React from 'react';
 import Header from './Header';
 import { shallow } from 'enzyme';
 
+const mockDispatch = jest.fn();
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch
+}));
+
 describe('Header time component', () => {
   it('should match the snapshot', () => {
     const wrapper = shallow(<Header />);

--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -1,16 +1,27 @@
 import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
 import { Redirect } from 'react-router-dom';
+import { removeCurrentBrainstorm, reverseInstructions, removeAllWords, removeInsights } from 'redux/actions';
 import './Header.scss';
 import back from 'assets/down.svg';
 
 const Header: React.FC = () => {
   const [ isRedirected, setIsRedirected ] = useState<boolean>(false);
+  const dispatch = useDispatch();
   const redirect = ():void => setIsRedirected(true);
+  
+  const backToDashboard = async () => {
+    await redirect();
+    dispatch(removeCurrentBrainstorm());
+    dispatch(reverseInstructions());
+    dispatch(removeAllWords());
+    dispatch(removeInsights());
+  };
 
   return (
     <header className="round-header">
       {isRedirected && <Redirect to="/dashboard" />}
-      <button onClick={redirect}>
+      <button onClick={backToDashboard}>
         <img src={back} alt="back"/>
         to dashboard
       </button>

--- a/src/Components/IdeaQuestion/IdeaQuestion.test.tsx
+++ b/src/Components/IdeaQuestion/IdeaQuestion.test.tsx
@@ -10,11 +10,11 @@ import IdeaQuestion from './IdeaQuestion';
 describe('IdeaQuestion Component', () => {
   let wrapper: any;
 
-  let mockFormState = {
+  let mockFormState: IBrainstormForm = {
     question: '',
     categories: [],
-    action: 'create an app',
-    reset: true
+    action: {id: 1, action: 'create an app'},
+    reset: false
   };
   let mockSetQuestion = jest.fn();
 
@@ -41,5 +41,22 @@ describe('IdeaQuestion Component', () => {
     const mockEvent: Object = {target: {value: 'What is love?'}}
     wrapper.find('input').simulate('change', mockEvent);
     expect(wrapper.find('input').getDOMNode().value).toEqual('What is love?')
+  });
+
+  it('should reset its state when formState.reset is true', () => {
+    let mockFormState: IBrainstormForm = {
+      question: '',
+      categories: [],
+      action: {id: 1, action: 'create an app'},
+      reset: true
+    };
+    wrapper = mount(<IdeaQuestion
+      formState={mockFormState}
+      setQuestion={mockSetQuestion}/>);
+
+
+  const mockEvent: Object = {target: {value: 'What is love?'}}
+  wrapper.find('input').simulate('change', mockEvent);
+  expect(wrapper.find('input').getDOMNode().value).toEqual('')
   });
 });

--- a/src/Components/IdeaQuestion/IdeaQuestion.tsx
+++ b/src/Components/IdeaQuestion/IdeaQuestion.tsx
@@ -9,13 +9,17 @@ interface Props {
 
 const IdeaQuestion:React.FC<Props> = ({ formState, setQuestion }) => {
   const [ questionValue, setQuestionValue ] = useState<string>('');
-
   const updateQuestion = ():void => setQuestion({...formState, question: questionValue});
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>):void => {
     setQuestionValue(e.target.value);
   };
 
   useEffect(updateQuestion, [questionValue]);
+  
+  useEffect(() => formState.reset 
+  ? setQuestionValue('') 
+  : setQuestionValue(questionValue)
+  , [formState.reset, questionValue]);
 
   return (
     <input

--- a/src/Components/IdeaQuestion/__snapshots__/IdeaQuestion.test.tsx.snap
+++ b/src/Components/IdeaQuestion/__snapshots__/IdeaQuestion.test.tsx.snap
@@ -4,10 +4,13 @@ exports[`IdeaQuestion Component should match the snapshot with all the data pass
 <IdeaQuestion
   formState={
     Object {
-      "action": "create an app",
+      "action": Object {
+        "action": "create an app",
+        "id": 1,
+      },
       "categories": Array [],
       "question": "",
-      "reset": true,
+      "reset": false,
     }
   }
   setQuestion={
@@ -15,10 +18,13 @@ exports[`IdeaQuestion Component should match the snapshot with all the data pass
       "calls": Array [
         Array [
           Object {
-            "action": "create an app",
+            "action": Object {
+              "action": "create an app",
+              "id": 1,
+            },
             "categories": Array [],
             "question": "",
-            "reset": true,
+            "reset": false,
           },
         ],
       ],

--- a/src/Components/UserProfile/UserProfile.tsx
+++ b/src/Components/UserProfile/UserProfile.tsx
@@ -13,7 +13,6 @@ import logout from '../../assets/logout.svg';
 
 const UserProfile:React.FC = () => {
   const dispatch = useDispatch();
-  const [ isLoggedIn, setLogIn ] = useState<boolean>(true)
   const { firstName, lastName } = useSelector((state:AppStore) => ({
     firstName: state.user.firstName,
     lastName: state.user.lastName
@@ -31,11 +30,6 @@ const UserProfile:React.FC = () => {
     setRedirected(true);
   };
 
-  const handleLogOut = ():void => {
-    logoutUser();
-    setLogIn(false);
-  }
-
   return (
     <div className='user-profile-div'>
       { isRedirected && <Redirect to='/' /> }
@@ -44,7 +38,7 @@ const UserProfile:React.FC = () => {
       {!isClicked
         ? <img className='menu-svg' src={menu} alt='menu-svg' onClick={toggleMenu} />
         : <section>
-          <img className='logout' src={logout} alt='logout' onClick={handleLogOut}/>
+          <img className='logout' src={logout} alt='logout' onClick={logoutUser}/>
           <img className='close' src={close} alt='close' onClick={toggleMenu} />
         </section>
       }

--- a/src/Components/UserProfile/UserProfile.tsx
+++ b/src/Components/UserProfile/UserProfile.tsx
@@ -13,6 +13,7 @@ import logout from '../../assets/logout.svg';
 
 const UserProfile:React.FC = () => {
   const dispatch = useDispatch();
+  const [ isLoggedIn, setLogIn ] = useState<boolean>(true)
   const { firstName, lastName } = useSelector((state:AppStore) => ({
     firstName: state.user.firstName,
     lastName: state.user.lastName
@@ -30,6 +31,11 @@ const UserProfile:React.FC = () => {
     setRedirected(true);
   };
 
+  const handleLogOut = ():void => {
+    logoutUser();
+    setLogIn(false);
+  }
+
   return (
     <div className='user-profile-div'>
       { isRedirected && <Redirect to='/' /> }
@@ -38,7 +44,7 @@ const UserProfile:React.FC = () => {
       {!isClicked
         ? <img className='menu-svg' src={menu} alt='menu-svg' onClick={toggleMenu} />
         : <section>
-          <img className='logout' src={logout} alt='logout' onClick={logoutUser}/>
+          <img className='logout' src={logout} alt='logout' onClick={handleLogOut}/>
           <img className='close' src={close} alt='close' onClick={toggleMenu} />
         </section>
       }

--- a/src/Containers/ActionsField/ActionsField.test.tsx
+++ b/src/Containers/ActionsField/ActionsField.test.tsx
@@ -2,21 +2,42 @@
  * @jest-environment jsdom
  */
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { IBrainstormForm } from '../../interfaces';
 import ActionsField from './ActionsField';
 
 jest.mock('react-redux', () => ({
-  useSelector: () => [{id: 1, action: 'Build an app'}]
+  useSelector: () => [
+    {id: 1, action: 'Create an App'},
+    {id: 2, action: 'Write a Story'},
+    {id: 3, action: 'Plan a Lesson'},
+    {id: 4, action: 'Make a Recipe'},
+    {id: 5, action: 'Write a Song'}
+  ]
 }));
 
 describe('ActionsField', () => {
-  let wrapper;
+  let wrapper: any;
+
+  let mockFormState: IBrainstormForm = {
+    question: '',
+    categories: [],
+    action: {id: 1, action: 'create an app'},
+    reset: false
+  };
+
+  let mockSetAction = jest.fn();
+
   beforeEach(() => {
     interface Props {
       formState: IBrainstormForm,
       setAction: (formState: IBrainstormForm) => void
     }
+
+    wrapper = mount(<ActionsField
+      formState={mockFormState}
+      setAction={mockSetAction}
+    />);
   });
 
   afterEach(() => {
@@ -24,63 +45,33 @@ describe('ActionsField', () => {
   });
 
   it('should match the snapshot', () => {
-    let mockFormState = {
-      question: '',
-      categories: [],
-      action: 'create an app',
-      reset: true
-    };
-
-    let mockSetAction = jest.fn();
-
-    wrapper = shallow(<ActionsField
-      formState={mockFormState}
-      setAction={mockSetAction}
-    />);
-
     expect(wrapper).toMatchSnapshot();
   });
-  // it('should call setAction when a change event occurs', () => {
-  //   let mockFormState = {
-  //     question: '',
-  //     categories: [],
-  //     action: 'create an app',
-  //     reset: true
-  //   };
-  //
-  //   let mockSetAction = jest.fn();
-  //
-  //   wrapper = mount(<ActionsField
-  //     formState={mockFormState}
-  //     setAction={mockSetAction}
-  //   />);
-  //
-  //   let mockEvent = {target: {value: 'Write a Book'}};
-  //
-  //   const instance = wrapper.instance();
-  //
-  //   wrapper.find('select').simulate('change', mockEvent);
-  //   expect(mockSetAction).toHaveBeenCalled();
-  // });
-  // it('should update the local state when change event occurs', () => {
-  //   let mockFormState = {
-  //     question: '',
-  //     categories: [],
-  //     action: 'create an app',
-  //     reset: true
-  //   };
-  //
-  //   let mockSetAction = jest.fn();
-  //
-  //   wrapper = mount(<ActionsField
-  //     formState={mockFormState}
-  //     setAction={mockSetAction}
-  //   />);
-  //
-  //   let mockEvent = {target: {value: 'Write a Book'}};
-  //
-  //   expect(wrapper.find('select').getDOMNode().value).toEqual('Create an App');
-  //   wrapper.find('select').simulate('change', mockEvent);
-  //   expect(wrapper).toMatchSnapshot();
-  // });
+
+  it('should display more actions when down arrow is clicked', () => {
+    wrapper.find('img').simulate('click');
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should call setAction/handleChange when a new li is clicked', () => {
+    const mockEvent: Object = {target: {innerText: 'Write a Song'}}
+    const instance = wrapper.instance();
+    wrapper.find('img').simulate('click');
+    wrapper.find('li').last().simulate('click', mockEvent);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should reset the local state when formState.reset is true', () => {
+    const mockEvent: Object = {target: {innerText: 'Write a Story'}};
+
+    wrapper.find('img').simulate('click');
+    wrapper.find('li').at(2).simulate('click', mockEvent);
+    expect(wrapper).toMatchSnapshot();
+
+    wrapper.setProps({formState: {...mockFormState, reset: true}, setAction: jest.fn()});
+    wrapper.update();
+
+    expect(wrapper).toMatchSnapshot();
+
+  });
 });

--- a/src/Containers/ActionsField/ActionsField.tsx
+++ b/src/Containers/ActionsField/ActionsField.tsx
@@ -40,6 +40,9 @@ const ActionsField:React.FC<Props> = ({ formState, setAction }) => {
   }
 
   useEffect(updateAction, [ selectedAction ]);
+  useEffect(() => {
+    if (formState.reset) return setSelectedAction({id: 1, action: 'Create an app'});
+  }, [formState]);
 
   const actions:(JSX.Element | null)[] = actionsCollection
     .map((action:Action) => {

--- a/src/Containers/ActionsField/__snapshots__/ActionsField.test.tsx.snap
+++ b/src/Containers/ActionsField/__snapshots__/ActionsField.test.tsx.snap
@@ -1,22 +1,253 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ActionsField should match the snapshot 1`] = `
-<div
-  className="action-toggle"
+exports[`ActionsField should call setAction/handleChange when a new li is clicked 1`] = `
+<ActionsField
+  formState={
+    Object {
+      "action": Object {
+        "action": "create an app",
+        "id": 1,
+      },
+      "categories": Array [],
+      "question": "",
+      "reset": false,
+    }
+  }
+  setAction={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          Object {
+            "action": Object {
+              "action": "Write a Song",
+              "id": 5,
+            },
+            "categories": Array [],
+            "question": "",
+            "reset": false,
+          },
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
 >
-  <header
-    className=""
-    onClick={[Function]}
+  <div
+    className="action-toggle"
   >
-    <p
-      className="chosen"
+    <header
+      className=""
+      onClick={[Function]}
     >
-      Create an app
-    </p>
-    <img
-      alt="down"
-      src="down.svg"
-    />
-  </header>
-</div>
+      <p
+        className="chosen"
+      >
+        Write a Song
+      </p>
+      <img
+        alt="down"
+        src="down.svg"
+      />
+    </header>
+  </div>
+</ActionsField>
+`;
+
+exports[`ActionsField should display more actions when down arrow is clicked 1`] = `
+<ActionsField
+  formState={
+    Object {
+      "action": Object {
+        "action": "create an app",
+        "id": 1,
+      },
+      "categories": Array [],
+      "question": "",
+      "reset": false,
+    }
+  }
+  setAction={[MockFunction]}
+>
+  <div
+    className="action-toggle"
+  >
+    <header
+      className="clicked"
+      onClick={[Function]}
+    >
+      <p
+        className="chosen"
+      >
+        Create an app
+      </p>
+      <img
+        alt="down"
+        src="down.svg"
+      />
+    </header>
+    <ul
+      className="clicked"
+    >
+      <li
+        key="2"
+        onClick={[Function]}
+      >
+        Write a Story
+      </li>
+      <li
+        key="3"
+        onClick={[Function]}
+      >
+        Plan a Lesson
+      </li>
+      <li
+        key="4"
+        onClick={[Function]}
+      >
+        Make a Recipe
+      </li>
+      <li
+        key="5"
+        onClick={[Function]}
+      >
+        Write a Song
+      </li>
+    </ul>
+  </div>
+</ActionsField>
+`;
+
+exports[`ActionsField should match the snapshot 1`] = `
+<ActionsField
+  formState={
+    Object {
+      "action": Object {
+        "action": "create an app",
+        "id": 1,
+      },
+      "categories": Array [],
+      "question": "",
+      "reset": false,
+    }
+  }
+  setAction={[MockFunction]}
+>
+  <div
+    className="action-toggle"
+  >
+    <header
+      className=""
+      onClick={[Function]}
+    >
+      <p
+        className="chosen"
+      >
+        Create an app
+      </p>
+      <img
+        alt="down"
+        src="down.svg"
+      />
+    </header>
+  </div>
+</ActionsField>
+`;
+
+exports[`ActionsField should reset the local state when formState.reset is true 1`] = `
+<ActionsField
+  formState={
+    Object {
+      "action": Object {
+        "action": "create an app",
+        "id": 1,
+      },
+      "categories": Array [],
+      "question": "",
+      "reset": false,
+    }
+  }
+  setAction={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          Object {
+            "action": Object {
+              "action": "Write a Story",
+              "id": 2,
+            },
+            "categories": Array [],
+            "question": "",
+            "reset": false,
+          },
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
+>
+  <div
+    className="action-toggle"
+  >
+    <header
+      className=""
+      onClick={[Function]}
+    >
+      <p
+        className="chosen"
+      >
+        Write a Story
+      </p>
+      <img
+        alt="down"
+        src="down.svg"
+      />
+    </header>
+  </div>
+</ActionsField>
+`;
+
+exports[`ActionsField should reset the local state when formState.reset is true 2`] = `
+<ActionsField
+  formState={
+    Object {
+      "action": Object {
+        "action": "create an app",
+        "id": 1,
+      },
+      "categories": Array [],
+      "question": "",
+      "reset": true,
+    }
+  }
+  setAction={[MockFunction]}
+>
+  <div
+    className="action-toggle"
+  >
+    <header
+      className=""
+      onClick={[Function]}
+    >
+      <p
+        className="chosen"
+      >
+        Create an app
+      </p>
+      <img
+        alt="down"
+        src="down.svg"
+      />
+    </header>
+  </div>
+</ActionsField>
 `;

--- a/src/Containers/BrainstormForm/BrainstormForm.test.tsx
+++ b/src/Containers/BrainstormForm/BrainstormForm.test.tsx
@@ -10,11 +10,14 @@ import { MemoryRouter } from 'react-router-dom';
 const mockDispatch = jest.fn();
 jest.mock('react-redux', () => ({
   useDispatch: () => mockDispatch,
-  useSelector: () => [{id: 1, action: 'Build'}]
+  useSelector: () => [{id: 1, action: 'Create an App'}]
 }));
 
 describe('BrainstormForm', () => {
   let wrapper: any;
+
+  const mockBrainstormFormState = true;
+  const mockCancel = jest.fn();
 
   beforeEach(() => {
     jest.mock('react-router-dom', () => ({
@@ -22,9 +25,6 @@ describe('BrainstormForm', () => {
         push: jest.fn(),
       }),
     }));
-
-    const mockBrainstormFormState = true;
-    const mockCancel = jest.fn();
 
     wrapper = mount(<MemoryRouter
       initialEntries={[ { pathname: '/', key: 'testKey' } ]}><BrainstormForm
@@ -41,17 +41,16 @@ describe('BrainstormForm', () => {
   });
 
   it('should call cancel when the button is clicked', () => {
-    const mockBrainstormFormState = true;
-    const mockCancel = jest.fn();
-
-    wrapper = mount(<MemoryRouter
-      initialEntries={[ { pathname: '/', key: 'testKey' } ]}><BrainstormForm
-      brainstormFormState={mockBrainstormFormState}
-      cancel={mockCancel}/></MemoryRouter>)
-
-    const instance = wrapper.instance();
-
     wrapper.find('.cancel-btn').simulate('click');
     expect(mockCancel).toHaveBeenCalled();
+  });
+
+  it('should reset state when resetForm is called', () => {
+    const mockEvent: Object = {target: {value: 'Who ate my cheeseburger?'}}
+    wrapper.find('input').simulate('change', mockEvent);
+    expect(wrapper).toMatchSnapshot();
+
+    wrapper.find('button').at(1).simulate('click');
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/Containers/BrainstormForm/BrainstormForm.tsx
+++ b/src/Containers/BrainstormForm/BrainstormForm.tsx
@@ -28,14 +28,18 @@ const BrainstormForm:React.FC<Props> = ({ brainstormFormState, cancel }) => {
   const dispatch = useDispatch();
   let history = useHistory();
 
+  const cancelForm = ():void => {
+    cancel(!brainstormFormState);
+  };
+
   const resetForm = ():void => {
-      // setFormState({
-      //   question: '',
-      //   categories: [],
-      //   action: {id: 1, 'create an app'},
-      //   reset: true
-      // })
-      cancel(!brainstormFormState);
+    setFormState({
+      question: '',
+      categories: [],
+      action: {id: 1, action: 'Create an App'},
+      reset: !formState.reset
+    });
+    setSummary('');
   };
 
   const validateFields = (state: IBrainstormForm): boolean => (
@@ -77,6 +81,10 @@ const BrainstormForm:React.FC<Props> = ({ brainstormFormState, cancel }) => {
   const toggleCategory = (): void => setIsClickedCategory(!isClickedCategory);
 
   useEffect(() => {
+    if (formState.reset) return setFormState({...formState, reset: false});
+  }, [formState]);
+
+  useEffect(() => {
     if (!formState.action) {
       setFormState({...formState, action: {id: 1, action: 'Create an App'}});
     }
@@ -111,8 +119,8 @@ const BrainstormForm:React.FC<Props> = ({ brainstormFormState, cancel }) => {
         <textarea readOnly className='brainstorm-summary-textarea' value={summary} placeholder='Typed summary here...'></textarea>
       </div>
       <div className='brainstorm-form-menu'>
-        <button type='button' className='cancel-btn' onClick={resetForm}>cancel</button>
-        <button className='clean-btn'><img className='broom' alt='broom-icon' src={broom}/></button>
+        <button type='button' className='cancel-btn' onClick={cancelForm}>cancel</button>
+        <button type='button' onClick={resetForm} className='clean-btn'><img className='broom' alt='broom-icon' src={broom}/></button>
         <button type='button' onClick={handleSubmit} disabled={disabled} className='start-btn'>start</button>
       </div>
     </form>

--- a/src/Containers/BrainstormForm/__snapshots__/BrainstormForm.test.tsx.snap
+++ b/src/Containers/BrainstormForm/__snapshots__/BrainstormForm.test.tsx.snap
@@ -192,3 +192,389 @@ exports[`BrainstormForm should match the snapshot 1`] = `
   </Router>
 </MemoryRouter>
 `;
+
+exports[`BrainstormForm should reset state when resetForm is called 1`] = `
+<MemoryRouter
+  initialEntries={
+    Array [
+      Object {
+        "key": "testKey",
+        "pathname": "/",
+      },
+    ]
+  }
+>
+  <Router
+    history={
+      Object {
+        "action": "POP",
+        "block": [Function],
+        "canGo": [Function],
+        "createHref": [Function],
+        "entries": Array [
+          Object {
+            "hash": "",
+            "key": "testKey",
+            "pathname": "/",
+            "search": "",
+          },
+        ],
+        "go": [Function],
+        "goBack": [Function],
+        "goForward": [Function],
+        "index": 0,
+        "length": 1,
+        "listen": [Function],
+        "location": Object {
+          "hash": "",
+          "key": "testKey",
+          "pathname": "/",
+          "search": "",
+        },
+        "push": [Function],
+        "replace": [Function],
+      }
+    }
+  >
+    <BrainstormForm
+      brainstormFormState={true}
+      cancel={[MockFunction]}
+    >
+      <form
+        className="brainstorm-form"
+      >
+        <h2
+          className="brainstorm-form-h2"
+        >
+          CREATE NEW BRAINSTORM
+        </h2>
+        <div
+          className="brainstorm-div"
+        >
+          <label
+            className="brainstorm-label"
+          >
+            IDEA QUESTION
+          </label>
+          <IdeaQuestion
+            formState={
+              Object {
+                "action": Object {
+                  "action": "Create an App",
+                  "id": 1,
+                },
+                "categories": Array [],
+                "question": "Who ate my cheeseburger?",
+                "reset": false,
+              }
+            }
+            setQuestion={[Function]}
+          >
+            <input
+              className="idea-question-input"
+              onChange={[Function]}
+              placeholder="Enter your idea here..."
+              type="text"
+              value="Who ate my cheeseburger?"
+            />
+          </IdeaQuestion>
+        </div>
+        <div
+          className="brainstorm-div"
+        >
+          <label
+            className="brainstorm-label"
+          >
+            CATEGORIES
+            <img
+              alt="down"
+              onClick={[Function]}
+              src="down.svg"
+            />
+          </label>
+        </div>
+        <div
+          className="brainstorm-div"
+        >
+          <label
+            className="brainstorm-label"
+          >
+            DESIRED ACTION
+          </label>
+          <ActionsField
+            formState={
+              Object {
+                "action": Object {
+                  "action": "Create an App",
+                  "id": 1,
+                },
+                "categories": Array [],
+                "question": "Who ate my cheeseburger?",
+                "reset": false,
+              }
+            }
+            setAction={[Function]}
+          >
+            <div
+              className="action-toggle"
+            >
+              <header
+                className=""
+                onClick={[Function]}
+              >
+                <p
+                  className="chosen"
+                >
+                  Create an app
+                </p>
+                <img
+                  alt="down"
+                  src="down.svg"
+                />
+              </header>
+            </div>
+          </ActionsField>
+        </div>
+        <div
+          className="brainstorm-div"
+        >
+          <label
+            className="brainstorm-label"
+          >
+            SUMMARY
+          </label>
+          <textarea
+            className="brainstorm-summary-textarea"
+            placeholder="Typed summary here..."
+            readOnly={true}
+            value=""
+          />
+        </div>
+        <div
+          className="brainstorm-form-menu"
+        >
+          <button
+            className="cancel-btn"
+            onClick={[Function]}
+            type="button"
+          >
+            cancel
+          </button>
+          <button
+            className="clean-btn"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt="broom-icon"
+              className="broom"
+              src="broom.svg"
+            />
+          </button>
+          <button
+            className="start-btn"
+            disabled={true}
+            onClick={[Function]}
+            type="button"
+          >
+            start
+          </button>
+        </div>
+      </form>
+    </BrainstormForm>
+  </Router>
+</MemoryRouter>
+`;
+
+exports[`BrainstormForm should reset state when resetForm is called 2`] = `
+<MemoryRouter
+  initialEntries={
+    Array [
+      Object {
+        "key": "testKey",
+        "pathname": "/",
+      },
+    ]
+  }
+>
+  <Router
+    history={
+      Object {
+        "action": "POP",
+        "block": [Function],
+        "canGo": [Function],
+        "createHref": [Function],
+        "entries": Array [
+          Object {
+            "hash": "",
+            "key": "testKey",
+            "pathname": "/",
+            "search": "",
+          },
+        ],
+        "go": [Function],
+        "goBack": [Function],
+        "goForward": [Function],
+        "index": 0,
+        "length": 1,
+        "listen": [Function],
+        "location": Object {
+          "hash": "",
+          "key": "testKey",
+          "pathname": "/",
+          "search": "",
+        },
+        "push": [Function],
+        "replace": [Function],
+      }
+    }
+  >
+    <BrainstormForm
+      brainstormFormState={true}
+      cancel={[MockFunction]}
+    >
+      <form
+        className="brainstorm-form"
+      >
+        <h2
+          className="brainstorm-form-h2"
+        >
+          CREATE NEW BRAINSTORM
+        </h2>
+        <div
+          className="brainstorm-div"
+        >
+          <label
+            className="brainstorm-label"
+          >
+            IDEA QUESTION
+          </label>
+          <IdeaQuestion
+            formState={
+              Object {
+                "action": Object {
+                  "action": "Create an App",
+                  "id": 1,
+                },
+                "categories": Array [],
+                "question": "",
+                "reset": false,
+              }
+            }
+            setQuestion={[Function]}
+          >
+            <input
+              className="idea-question-input"
+              onChange={[Function]}
+              placeholder="Enter your idea here..."
+              type="text"
+              value=""
+            />
+          </IdeaQuestion>
+        </div>
+        <div
+          className="brainstorm-div"
+        >
+          <label
+            className="brainstorm-label"
+          >
+            CATEGORIES
+            <img
+              alt="down"
+              onClick={[Function]}
+              src="down.svg"
+            />
+          </label>
+        </div>
+        <div
+          className="brainstorm-div"
+        >
+          <label
+            className="brainstorm-label"
+          >
+            DESIRED ACTION
+          </label>
+          <ActionsField
+            formState={
+              Object {
+                "action": Object {
+                  "action": "Create an App",
+                  "id": 1,
+                },
+                "categories": Array [],
+                "question": "",
+                "reset": false,
+              }
+            }
+            setAction={[Function]}
+          >
+            <div
+              className="action-toggle"
+            >
+              <header
+                className=""
+                onClick={[Function]}
+              >
+                <p
+                  className="chosen"
+                >
+                  Create an app
+                </p>
+                <img
+                  alt="down"
+                  src="down.svg"
+                />
+              </header>
+            </div>
+          </ActionsField>
+        </div>
+        <div
+          className="brainstorm-div"
+        >
+          <label
+            className="brainstorm-label"
+          >
+            SUMMARY
+          </label>
+          <textarea
+            className="brainstorm-summary-textarea"
+            placeholder="Typed summary here..."
+            readOnly={true}
+            value=""
+          />
+        </div>
+        <div
+          className="brainstorm-form-menu"
+        >
+          <button
+            className="cancel-btn"
+            onClick={[Function]}
+            type="button"
+          >
+            cancel
+          </button>
+          <button
+            className="clean-btn"
+            onClick={[Function]}
+            type="button"
+          >
+            <img
+              alt="broom-icon"
+              className="broom"
+              src="broom.svg"
+            />
+          </button>
+          <button
+            className="start-btn"
+            disabled={true}
+            onClick={[Function]}
+            type="button"
+          >
+            start
+          </button>
+        </div>
+      </form>
+    </BrainstormForm>
+  </Router>
+</MemoryRouter>
+`;

--- a/src/Containers/BrainstormForm/__snapshots__/BrainstormForm.test.tsx.snap
+++ b/src/Containers/BrainstormForm/__snapshots__/BrainstormForm.test.tsx.snap
@@ -169,6 +169,8 @@ exports[`BrainstormForm should match the snapshot 1`] = `
           </button>
           <button
             className="clean-btn"
+            onClick={[Function]}
+            type="button"
           >
             <img
               alt="broom-icon"

--- a/src/Containers/BubblesAll/BubblesAll.tsx
+++ b/src/Containers/BubblesAll/BubblesAll.tsx
@@ -2,7 +2,7 @@ import React, {useState, useEffect} from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { AppStore, WordSample } from 'interfaces';
 import { Redirect } from 'react-router-dom';
-import { addChosenWord, reverseInstructions } from 'redux/actions';
+import { addChosenWord, reverseInstructions, addForgottenWords } from 'redux/actions';
 
 const BubblesAll: React.FC = () => {
   const dispatch = useDispatch();
@@ -15,6 +15,16 @@ const BubblesAll: React.FC = () => {
   const firstStack: string[] = randomWords.splice(0, 8);
 
   const [ bubbles, setBubbles ] = useState<string[]>(firstStack);
+  
+  const addWords = () => {
+    setTimeout(() => {
+      let num = Math.floor((Math.random() * 61));
+      dispatch(addForgottenWords(randomWordCollections
+        .slice(num, num + 3)
+        .map((wordObj:WordSample) => wordObj.word)
+        ))}, 2000);
+    return <Redirect to='/instructions/second-rd' />
+  }
 
   useEffect(() => {
     dispatch(reverseInstructions());
@@ -23,7 +33,9 @@ const BubblesAll: React.FC = () => {
       setBubbles(randomWords.splice(0, 8));
     }, 8000);
 
-    return () => clearInterval(timer);
+    return () => {
+      clearInterval(timer);
+    }
   }, []); //eslint-disable-line
 
   const sendToChosen = (event: React.MouseEvent): void => {
@@ -45,7 +57,7 @@ const BubblesAll: React.FC = () => {
     <section className="all-bbls">
       { !timeEnded
         ? bubbleEls
-        : <Redirect to='/instructions/second-rd' />
+        : addWords()
       }
     </section>
   );

--- a/src/Containers/BubblesAll/BubblesAll.tsx
+++ b/src/Containers/BubblesAll/BubblesAll.tsx
@@ -13,7 +13,6 @@ const BubblesAll: React.FC = () => {
 
   let randomWords: string[] = randomWordCollections.map((word: WordSample) => word.word)
   const firstStack: string[] = randomWords.splice(0, 8);
-
   const [ bubbles, setBubbles ] = useState<string[]>(firstStack);
   
   useEffect(() => {

--- a/src/Containers/BubblesAll/BubblesAll.tsx
+++ b/src/Containers/BubblesAll/BubblesAll.tsx
@@ -16,16 +16,6 @@ const BubblesAll: React.FC = () => {
 
   const [ bubbles, setBubbles ] = useState<string[]>(firstStack);
   
-  const addWords = () => {
-    setTimeout(() => {
-      let num = Math.floor((Math.random() * 61));
-      dispatch(addForgottenWords(randomWordCollections
-        .slice(num, num + 3)
-        .map((wordObj:WordSample) => wordObj.word)
-        ))}, 2000);
-    return <Redirect to='/instructions/second-rd' />
-  }
-
   useEffect(() => {
     dispatch(reverseInstructions());
 
@@ -52,6 +42,16 @@ const BubblesAll: React.FC = () => {
       <button id={bubble.toLowerCase()} onClick={sendToChosen}>{bubble}</button>
     </p>
   ));
+
+  const addWords = () => {
+    setTimeout(() => {
+      let num = Math.floor((Math.random() * 61));
+      dispatch(addForgottenWords(randomWordCollections
+        .slice(num, num + 3)
+        .map((wordObj:WordSample) => wordObj.word)
+        ))}, 2000);
+    return <Redirect to='/instructions/second-rd' />
+  };
 
   return (
     <section className="all-bbls">

--- a/src/Containers/BubblesAll/BubblesAll.tsx
+++ b/src/Containers/BubblesAll/BubblesAll.tsx
@@ -22,9 +22,7 @@ const BubblesAll: React.FC = () => {
       setBubbles(randomWords.splice(0, 8));
     }, 8000);
 
-    return () => {
-      clearInterval(timer);
-    }
+    return () => clearInterval(timer);
   }, []); //eslint-disable-line
 
   const sendToChosen = (event: React.MouseEvent): void => {

--- a/src/Containers/CategoriesField/CategoriesField.test.tsx
+++ b/src/Containers/CategoriesField/CategoriesField.test.tsx
@@ -4,6 +4,16 @@ import { IBrainstormForm } from '../../interfaces';
 import CategoriesField from './CategoriesField';
 import mockCategories from '../../data/mockCategories';
 
+jest.mock('react-redux', () => ({
+  useSelector: () => [
+    {id: 1, name: 'Education'},
+    {id: 2, name: 'Technology'},
+    {id: 3, name: 'Environment'},
+    {id: 4, name: 'Food'},
+    {id: 5, name: 'Music'}
+  ]
+}));
+
 describe('CategoriesField', () => {
   let wrapper;
   beforeEach(() => {

--- a/src/Containers/CategoriesField/CategoriesField.tsx
+++ b/src/Containers/CategoriesField/CategoriesField.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import './CategoriesField.scss';
+import { useSelector } from 'react-redux';
+import { AppStore } from 'interfaces';
 import BrainstormCategory from '../../Components/BrainstormCategory/BrainstormCategory';
-import mockCategories from '../../data/mockCategories';
+// import mockCategories from '../../data/mockCategories';
 // import addIcon from '../../assets/add.svg';
 import { IBrainstormForm, Category } from '../../interfaces';
 
@@ -11,7 +13,8 @@ interface Props {
 };
 
 const CategoryField:React.FC<Props>= ({ formState, setCategory }) => {
-  const categories: JSX.Element[] = mockCategories.map((category: Category, index:number) => (
+  const categoriesData = useSelector((store:AppStore) => store.categories)
+  const categories: JSX.Element[] = categoriesData.map((category: Category, index:number) => (
     <BrainstormCategory
       key={index}
       category={category}

--- a/src/Containers/CategoriesField/CategoriesField.tsx
+++ b/src/Containers/CategoriesField/CategoriesField.tsx
@@ -3,7 +3,6 @@ import './CategoriesField.scss';
 import { useSelector } from 'react-redux';
 import { AppStore } from 'interfaces';
 import BrainstormCategory from '../../Components/BrainstormCategory/BrainstormCategory';
-// import mockCategories from '../../data/mockCategories';
 // import addIcon from '../../assets/add.svg';
 import { IBrainstormForm, Category } from '../../interfaces';
 

--- a/src/Containers/RoundTwo/RoundTwo.tsx
+++ b/src/Containers/RoundTwo/RoundTwo.tsx
@@ -84,7 +84,7 @@ const RoundTwo:React.FC = () => {
         <ExampleSentence exampleSentence={prompts[currentStep].sentence}/>
         <section className='responses-section'>
           <header>
-            <input id='responses-input' onKeyDown={handleInputSubmit} onChange={handleChange}
+            <input id='responses-input' maxLength={100} onKeyDown={handleInputSubmit} onChange={handleChange}
             type='text' value={inputValue} autoComplete='off' placeholder='Write your question here...' />
             <img src={Check} onClick={handleSubmit} alt='submit-checkmark-icon' />
           </header>

--- a/src/Containers/RoundTwo/__snapshots__/RoundTwo.test.tsx.snap
+++ b/src/Containers/RoundTwo/__snapshots__/RoundTwo.test.tsx.snap
@@ -84,6 +84,7 @@ exports[`RoundTwo Component should match the snapshot when rendering for the fir
               <input
                 autoComplete="off"
                 id="responses-input"
+                maxLength={100}
                 onChange={[Function]}
                 onKeyDown={[Function]}
                 placeholder="Write your question here..."

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -168,6 +168,10 @@ export interface IAddInsightAction {
   insight: Insight
 }
 
+export interface IRemoveInsightsAction {
+  type: 'REMOVE_INSIGHTS'
+}
+
 export interface IAddQueryAction {
   type: 'ADD_QUERY',
   query: string

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -158,6 +158,11 @@ export interface IAddChosenWordAction {
   chosenWord: string
 }
 
+export interface IAddForgottenWordsAction {
+  type: 'ADD_FORGOTTEN_WORDS',
+  forgottenWords: string[]
+}
+
 export interface IRemoveChosenWordAction {
   type: 'REMOVE_WORD',
   chosenWord: string

--- a/src/redux/actions/actions.test.ts
+++ b/src/redux/actions/actions.test.ts
@@ -269,6 +269,19 @@ describe("chosenWords", () => {
     expect(result).toEqual(expected);
   });
 
+  it("should return object with a type of ADD_FORGOTTEN_WORDS when addForgottenWords is called", () => {
+    const mockForgottenWords: string[] = ['Elephant', 'Novel', 'Biscuits'];
+
+    const expected: interfaces.IAddForgottenWordsAction = {
+      type: 'ADD_FORGOTTEN_WORDS',
+      forgottenWords: mockForgottenWords
+    };
+
+    const result = actions.addForgottenWords(mockForgottenWords);
+
+    expect(result).toEqual(expected);
+  });
+
   it("should return object with a type of REMOVE_WORD when removeChosenWord is called", () => {
     const wordMock: string = 'Elephant';
 
@@ -310,6 +323,15 @@ describe("insights", () => {
     };
 
     const result = actions.addInsight(insightMock)
+
+    expect(result).toEqual(expected);
+  });
+  it("should return object with a type of REMOVE_INSIGHTS when removeInsights is called", () => {
+    const expected: interfaces.IRemoveInsightsAction = {
+      type: 'REMOVE_INSIGHTS',
+    };
+
+    const result = actions.removeInsights()
 
     expect(result).toEqual(expected);
   });

--- a/src/redux/actions/index.ts
+++ b/src/redux/actions/index.ts
@@ -21,6 +21,7 @@ import {
   IAddCurrentBrainstormAction,
   IRemoveCurrentBrainstormAction,
   IAddChosenWordAction,
+  IAddForgottenWordsAction,
   IRemoveChosenWordAction,
   IAddInsightAction,
   IRemoveInsightsAction,
@@ -121,6 +122,11 @@ export const removeCurrentBrainstorm = (): IRemoveCurrentBrainstormAction => ({
 export const addChosenWord = (chosenWord: string): IAddChosenWordAction => ({
   type: 'ADD_WORD',
   chosenWord: chosenWord
+});
+
+export const addForgottenWords = (forgottenWords: string[]): IAddForgottenWordsAction => ({
+  type: 'ADD_FORGOTTEN_WORDS',
+  forgottenWords: forgottenWords
 });
 
 export const removeChosenWord = (chosenWord: string): IRemoveChosenWordAction => ({

--- a/src/redux/actions/index.ts
+++ b/src/redux/actions/index.ts
@@ -23,6 +23,7 @@ import {
   IAddChosenWordAction,
   IRemoveChosenWordAction,
   IAddInsightAction,
+  IRemoveInsightsAction,
   IAddQueryAction,
   IRemoveQueryAction,
   IAddFilterAction,
@@ -135,6 +136,10 @@ export const removeAllWords = (): IRemoveAllWordsAction => ({
 export const addInsight = (insight: Insight): IAddInsightAction => ({
   type: 'ADD_INSIGHT',
   insight: insight
+});
+
+export const removeInsights = (): IRemoveInsightsAction => ({
+  type: 'REMOVE_INSIGHTS'
 });
 
 // query reducer action creators

--- a/src/redux/reducers/chosenWords/chosenWords.test.ts
+++ b/src/redux/reducers/chosenWords/chosenWords.test.ts
@@ -1,5 +1,5 @@
 import chosenWordsReducer from './chosenWords';
-import { ActionObject, IAddChosenWordAction, IRemoveChosenWordAction, IRemoveAllWordsAction, ICleanStore } from 'interfaces';
+import { ActionObject, IAddChosenWordAction, IAddForgottenWordsAction, IRemoveChosenWordAction, IRemoveAllWordsAction, ICleanStore } from 'interfaces';
 
 type emptyArray = [ ];
 
@@ -26,6 +26,22 @@ describe('chosenWordsReducer', () => {
     const expected: string[] = [mockChosenWord];
 
     const result: string[] = chosenWordsReducer(undefined, mockAction);
+
+    expect(result).toEqual(expected);
+  });
+
+  it("should return an array with three words if type of action is ADD_FORGOTTEN_WORDS", () => {
+    const mockState:string[] = ['Community']
+    const mockForgottenWords: string[] = ['Bear','Pie','Fly'];
+
+    const mockAction: IAddForgottenWordsAction = {
+      type: 'ADD_FORGOTTEN_WORDS',
+      forgottenWords: mockForgottenWords
+    };
+
+    const expected: string[] = ['Community', 'Bear', 'Pie'];
+
+    const result: string[] = chosenWordsReducer(mockState, mockAction);
 
     expect(result).toEqual(expected);
   });

--- a/src/redux/reducers/chosenWords/chosenWords.ts
+++ b/src/redux/reducers/chosenWords/chosenWords.ts
@@ -6,6 +6,9 @@ const chosenWords = (state: state = [ ], action: ActionObject) => {
   switch(action.type) {
     case 'ADD_WORD':
       return [...state, action.chosenWord];
+    case 'ADD_FORGOTTEN_WORDS':
+      let num = action.forgottenWords.length - state.length;
+      return [...state, ...action.forgottenWords.slice(0, num)];
     case 'REMOVE_WORD':
       return state.filter(word => word !== action.chosenWord);
     case 'REMOVE_ALL_WORDS':

--- a/src/redux/reducers/insights/insights.test.ts
+++ b/src/redux/reducers/insights/insights.test.ts
@@ -1,5 +1,5 @@
 import insightsReducer from './insights';
-import { ActionObject, Insight, IAddInsightAction, ICleanStore } from 'interfaces';
+import { ActionObject, Insight, IAddInsightAction, ICleanStore, IRemoveInsightsAction } from 'interfaces';
 
 type emptyArray = [];
 
@@ -40,6 +40,16 @@ describe('insightsReducer', () => {
   it("should return the empty array if type of action is CLEAN_STORE", () => {
     const mockAction: ICleanStore = {
       type: 'CLEAN_STORE'
+    };
+
+    const expected: emptyArray = [ ];
+    const result = insightsReducer([mockInsight], mockAction);
+
+    expect(result).toEqual(expected);
+  });
+  it("should return the empty array if type of action is REMOVE_INSIGHTS", () => {
+    const mockAction: IRemoveInsightsAction = {
+      type: 'REMOVE_INSIGHTS'
     };
 
     const expected: emptyArray = [ ];

--- a/src/redux/reducers/insights/insights.ts
+++ b/src/redux/reducers/insights/insights.ts
@@ -8,6 +8,8 @@ const insights = (state: state = [], action: ActionObject) => {
       return [...state, action.insight];
     case 'CLEAN_STORE':
       return [ ];
+    case 'REMOVE_INSIGHTS':
+      return [ ];
     default:
       return state;
   }


### PR DESCRIPTION
### What does this PR do? 

-This PR resolves some bugs and buggy styles. Particularly it fixes the bug that if a user were to not select any words in RoundOne the app would break. 

-updates the store if a user were to bail out on a currentBrainstorm session by clicking back to Dashboard in the Header

-It also sets a fixed max-width for the insight-divs for RoundTwo so that a longer question will not expand the width of the container. Also does this by setting a 100 character limit on the input. 

-This PR also adds some new functionality by enabling resetForm functionality 🚀! 

-Updates tests for ActionsField, BrainstormCategory, BrainstormForm, IdeaQuestion, insights reducer, chosenWords reducer, and actions.

-Also updates CategoriesField to receive its data from the store and not from mockData

### Where should the reviewer start? 

Reviewer can start by looking at how the resetForm functionality is working. Then hop on over to the Header component to see how the backToDashboard method is working. 

Then take a peek at how the RemoveInsights and AddForgottenWords action creators/reducers have been added. 

They can then look at how the styles for RoundTwo and GenerateInsights have been modified to no longer allow extensive question width to expand. 

### Can this be manually tested?

YES! All tests are passing, and the above mentioned tests have been updated.

~**Note**: This PR is not quite ready to be pulled in yet, as there needs to be testing added for the two new action creators / reducer cases (AddForgottenWords + RemoveInsights). But if you want to take a peek and get started on a code review by all means.~